### PR TITLE
Assertion from reloading loaded multiindex

### DIFF
--- a/util/multiindex.c
+++ b/util/multiindex.c
@@ -37,7 +37,10 @@ void multiindex_unload_starkd(multiindex_t* mi) {
 int multiindex_reload_starkd(multiindex_t* mi) {
     int i;
     assert(mi->fits);
-    assert(!(mi->starkd));
+    if (mi->starkd) {
+        // It's already loaded
+        return 0;
+    }
     mi->starkd = startree_open_fits(mi->fits);
     if (!mi->starkd) {
         ERROR("Failed to open multi-index star kdtree");


### PR DESCRIPTION
In version 0.50, `multiindex_reload_starkd()` has an `assert` that the data isn't loaded.  It seems silly to kill the entire world because the data that should be loaded has already been loaded.  It should simply `return 0` in that case.

I'm happy to provide a patch if desired.