### PR TITLE
Try importing pyfits then try astropy

### DIFF
--- a/blind/anet.py
+++ b/blind/anet.py
@@ -33,7 +33,13 @@ import threading
 import mimetools, mimetypes
 import os, stat
 from cStringIO import StringIO
-import pyfits 
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 import time
 
 __author__  = "J. S. Bloom"

--- a/blind/centroid-noise.py
+++ b/blind/centroid-noise.py
@@ -7,7 +7,13 @@ from math import pi
 from pylab import *
 from numpy import *
 from numpy.random import *
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 # Given an image and an xylist (including estimated image sigma),
 # look at a cutout around each source position, add noise, and recompute

--- a/blind/image2xy.py
+++ b/blind/image2xy.py
@@ -42,7 +42,13 @@ MODIFICATION HISTORY:
 # You need ctypes and a recent (1.0) numpy for this to work. I've included
 # pyfits so you don't have to. 
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 import sys
 import scipy
 import os

--- a/blind/spoof.py
+++ b/blind/spoof.py
@@ -1,4 +1,10 @@
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 import math
 from math import exp
 from matplotlib.pylab import imread

--- a/blind/test_plotstuff.py
+++ b/blind/test_plotstuff.py
@@ -3,7 +3,13 @@ if __name__ == '__main__':
 	matplotlib.use('Agg')
 import unittest
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 import numpy as np
 import pylab as plt
 from math import pi,sqrt

--- a/blind/test_plotstuff2.py
+++ b/blind/test_plotstuff2.py
@@ -2,7 +2,13 @@ import matplotlib
 if __name__ == '__main__':
 	matplotlib.use('Agg')
 import unittest
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from astrometry.util.fits import *
 from astrometry.blind.plotstuff import *
 import numpy as np

--- a/blind/ver.py
+++ b/blind/ver.py
@@ -1,5 +1,11 @@
 import math
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 from matplotlib.pylab import figure, plot, xlabel, ylabel, loglog, clf
 from matplotlib.pylab import semilogy, show, find, legend, hist, axis

--- a/catalogs/ngc2000tofits.py
+++ b/catalogs/ngc2000tofits.py
@@ -1,4 +1,10 @@
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 from ngc2000 import ngc2000, ngc2000accurate
 from astrometry.util.fits import *

--- a/net/process_submissions.py
+++ b/net/process_submissions.py
@@ -29,7 +29,13 @@ import django
 django.setup()
 
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 
 import tempfile

--- a/sdss/common.py
+++ b/sdss/common.py
@@ -2,7 +2,13 @@ import os
 from astrometry.util.fits import fits_table
 from astrometry.util.miscutils import get_overlapping_region
 import numpy as np
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 try:
     import cutils

--- a/sdss/dr10.py
+++ b/sdss/dr10.py
@@ -1,5 +1,11 @@
 import os
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from astrometry.util.fits import fits_table
 import numpy as np
 

--- a/sdss/dr8.py
+++ b/sdss/dr8.py
@@ -9,7 +9,13 @@ fitsio = None
 try:
     import fitsio
 except:
-    import pyfits
+    try:
+        import pyfits
+    except ImportError:
+        try:
+            from astropy.io import fits as pyfits
+        except ImportError:
+            raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 from common import *
 from dr7 import *

--- a/sdss/dr9.py
+++ b/sdss/dr9.py
@@ -1,5 +1,11 @@
 import os
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from astrometry.util.fits import fits_table
 import numpy as np
 

--- a/util/2mass_catalog.py
+++ b/util/2mass_catalog.py
@@ -2,7 +2,13 @@
 import sys
 from optparse import OptionParser
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 
 from astrometry.util.fits import *

--- a/util/fits.py
+++ b/util/fits.py
@@ -7,7 +7,13 @@ try:
     pyfits = NoPyfits()
 except:
     try:
-        import pyfits
+        try:
+            import pyfits
+        except ImportError:
+            try:
+                from astropy.io import fits as pyfits
+            except ImportError:
+                raise ImportError("Cannot import either pyfits or astropy.io.fits")
     except:
         pyfits = NoPyfits()
 import numpy as np
@@ -686,17 +692,25 @@ def fits_table(dataorfn=None, rows=None, hdunum=1, hdu=None, ext=None,
             # in a try/catch in case pyfits isn't available
             isrecarray = (type(data) == pyfits.core.FITS_rec)
         except:
-            import traceback
-            traceback.print_exc()
-            pass
+            try:
+                from astropy.io import fits as pyfits
+                isrecarray = (type(data) == pyfits.core.FITS_rec)
+            except:
+                import traceback
+                traceback.print_exc()
+                pass
         if not isrecarray:
             try:
                 import pyfits.fitsrec
                 isrecarray = (type(data) == pyfits.fitsrec.FITS_rec)
             except:
-                import traceback
-                traceback.print_exc()
-                pass
+                try:
+                    from astropy.io import fits as pyfits
+                    isrecarray = (type(data) == pyfits.fitsrec.FITS_rec)
+                except:
+                    import traceback
+                    traceback.print_exc()
+                    pass
         #if not isrecarray:
         #    if type(data) == np.recarray:
         #        isrecarray = True

--- a/util/fits2fits.py
+++ b/util/fits2fits.py
@@ -16,9 +16,21 @@ if __name__ == '__main__':
     # of the path: astrometry to pick up pyfits, and .. to pick up astrometry itself.
     sys.path.insert(1, andir)
     sys.path.insert(2, rootdir)
-    import pyfits
+    try:
+        import pyfits
+    except ImportError:
+        try:
+            from astropy.io import fits as pyfits
+        except ImportError:
+            raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from astrometry.util.fits import pyfits_writeto
 
 def fits2fits(infile, outfile, verbose=False, fix_idr=False):

--- a/util/fix_sdss_idr.py
+++ b/util/fix_sdss_idr.py
@@ -1,5 +1,11 @@
 import sys
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 import numpy
 
 from astrometry.util.fits import pyfits_writeto

--- a/util/hpimage.py
+++ b/util/hpimage.py
@@ -1,7 +1,13 @@
 import sys
 
 from pylab import *
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 
 from astrometry.util.healpix import *

--- a/util/matchfile_to_wcs.py
+++ b/util/matchfile_to_wcs.py
@@ -1,4 +1,10 @@
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from optparse import OptionParser
 from astrometry.util.fits import *
 

--- a/util/removelines.py
+++ b/util/removelines.py
@@ -9,7 +9,13 @@ if __name__ == '__main__':
     addpath.addpath()
 
 import numpy
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 from numpy.random import rand
 from astrometry.util.fits import pyfits_writeto

--- a/util/removelines_general.py
+++ b/util/removelines_general.py
@@ -1,7 +1,13 @@
 #! /usr/bin/env python
 
 import sys
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 from math import *
 from numpy import *

--- a/util/removelines_rotate.py
+++ b/util/removelines_rotate.py
@@ -13,7 +13,15 @@ from astrometry.util.fits import pyfits_writeto
 
 if __name__ == '__main__':
 	try:
-		import pyfits
+                try:
+                        import pyfits
+                except ImportError:
+                        try:
+                                from astropy.io import fits as pyfits
+                        except ImportError:
+                                raise ImportError(
+                                        "Cannot import either pyfits or astropy.io.fits"
+                                        )
 		import astrometry
 		from astrometry.util.shell import shell_escape
 		from astrometry.util.filetype import filetype_short
@@ -33,7 +41,13 @@ if __name__ == '__main__':
 		sys.path.insert(2, rootdir)
 
 import numpy
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+        except ImportError:
+            raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 from numpy.random import rand
 

--- a/util/sdss_astrom.py
+++ b/util/sdss_astrom.py
@@ -8,7 +8,13 @@
 
 from astrometry.util.fits import *
 from numpy import *
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from glob import glob
 
 def tsfield_get_node_incl(tsfield):

--- a/util/sdss_cutout.py
+++ b/util/sdss_cutout.py
@@ -2,9 +2,14 @@
 
 import os
 import sys
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from astrometry.util.util import *
-import pyfits
 from astrometry.util.sdss_noise import *
 from astrometry.util.sdss_psfield import *
 

--- a/util/sdss_photom.py
+++ b/util/sdss_photom.py
@@ -8,7 +8,13 @@
 from astrometry.util.fits import *
 from numpy import *
 import numpy as np
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 class PhotometricCalib(object):
 	def __init__(self, tsfieldfn):

--- a/util/tstimg.py
+++ b/util/tstimg.py
@@ -1,4 +1,10 @@
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 
 if __name__ == '__main__':

--- a/util/uniformize.py
+++ b/util/uniformize.py
@@ -6,7 +6,13 @@ from optparse import OptionParser
 
 if __name__ == '__main__':
     try:
-        import pyfits
+        try:
+            import pyfits
+        except ImportError:
+            try:
+                from astropy.io import fits as pyfits
+            except ImportError:
+                raise ImportError("Cannot import either pyfits or astropy.io.fits")
         import astrometry
         from astrometry.util.shell import shell_escape
         from astrometry.util.filetype import filetype_short
@@ -24,7 +30,13 @@ import numpy
 from numpy import *
 from numpy.random import rand
 from astrometry.util.fits import *
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 
 def uniformize(infile, outfile, n, xcol='X', ycol='Y', ext=1, **kwargs):
     p = pyfits.open(infile)

--- a/util/usnob_catalog.py
+++ b/util/usnob_catalog.py
@@ -2,7 +2,13 @@
 import sys
 from optparse import OptionParser
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 
 from astrometry.util.fits import *

--- a/util/usnob_trim.py
+++ b/util/usnob_trim.py
@@ -6,7 +6,13 @@
 import sys
 from optparse import OptionParser
 
-import pyfits
+try:
+    import pyfits
+except ImportError:
+    try:
+        from astropy.io import fits as pyfits
+    except ImportError:
+        raise ImportError("Cannot import either pyfits or astropy.io.fits")
 from numpy import *
 
 from astrometry.util.fits import *


### PR DESCRIPTION
The `pyfits` package is being merged into [astropy](http://www.astropy.org/) - deprecation notice ([source](http://www.stsci.edu/institute/software_hardware/pyfits)):

> Important notice regarding the future of PyFITS

> All of the functionality of PyFITS is now available in Astropy as the astropy.io.fits package, which is now publicly available. Although we will continue to release PyFITS separately in the short term, including any critical bug fixes, we will eventually stop releasing new versions of PyFITS as a stand-alone product. The exact timing of when we will discontinue new PyFITS releases is not yet settled, but users should not expect PyFITS releases to extend much past early 2014. Users of PyFITS should plan to make suitable changes to support the transition to Astropy on such a timescale. For the vast majority of users this transition is mainly a matter of changing the import statements in their code--all APIs are otherwise identical to PyFITS. STScI will continue to provide support for questions related to PyFITS and to the new astropy.io.fits package in Astropy.

The changes made in this PR change all occurrences of `import pyfits` to:

```
try:
    import pyfits
except ImportError:
    try:
        from astropy.io import fits as pyfits
    except ImportError:
        raise ImportError("Cannot import either pyfits or astropy.io.fits")
```

It attempts to import pyfits first, as per previous behaviour, and if missing attempts to install astropy. When `pyfits` becomes finally merged into `astropy` the order could then easily be switched.