### PR TITLE
Change license texts from GPL version 2 only to GPL version 2 or later

### DIFF
--- a/blind/agreeable.c
+++ b/blind/agreeable.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/allquads-main.c
+++ b/blind/allquads-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/allquads.c
+++ b/blind/allquads.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/augment-xylist-main.c
+++ b/blind/augment-xylist-main.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/augment-xylist.c
+++ b/blind/augment-xylist.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/bgsubtract.c
+++ b/blind/bgsubtract.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/blind-main.c
+++ b/blind/blind-main.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/blind.c
+++ b/blind/blind.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/blindutils.c
+++ b/blind/blindutils.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/build-index-main.c
+++ b/blind/build-index-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/build-index.c
+++ b/blind/build-index.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/catalog.c
+++ b/blind/catalog.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/catalog_analysis.c
+++ b/blind/catalog_analysis.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/certifiable.c
+++ b/blind/certifiable.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/checkquads.c
+++ b/blind/checkquads.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/codefile.c
+++ b/blind/codefile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/codeprojections.c
+++ b/blind/codeprojections.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/codetree-main.c
+++ b/blind/codetree-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/codetree.c
+++ b/blind/codetree.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/control-program.c
+++ b/blind/control-program.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/create-scamp-catalog.c
+++ b/blind/create-scamp-catalog.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/cut-table.c
+++ b/blind/cut-table.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/cut-table.h
+++ b/blind/cut-table.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/diffractionFlag_check.c
+++ b/blind/diffractionFlag_check.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/engine-main.c
+++ b/blind/engine-main.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/engine.c
+++ b/blind/engine.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/fits-guess-scale-main.c
+++ b/blind/fits-guess-scale-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/fits-guess-scale.c
+++ b/blind/fits-guess-scale.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/fitscopy.c
+++ b/blind/fitscopy.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/fitstomatlab.c
+++ b/blind/fitstomatlab.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/get-wcs.c
+++ b/blind/get-wcs.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/hpgrid.c
+++ b/blind/hpgrid.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/hpowned.c
+++ b/blind/hpowned.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/hpquads-main.c
+++ b/blind/hpquads-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/hpquads.c
+++ b/blind/hpquads.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/image2xy-files.c
+++ b/blind/image2xy-files.c
@@ -6,7 +6,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/image2xy-main.c
+++ b/blind/image2xy-main.c
@@ -6,7 +6,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/image2xy.py
+++ b/blind/image2xy.py
@@ -3,7 +3,8 @@
 #
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 #
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/imarith.c
+++ b/blind/imarith.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/imcopy.c
+++ b/blind/imcopy.c
@@ -14,7 +14,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/index-info.c
+++ b/blind/index-info.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/index-stats.c
+++ b/blind/index-stats.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/index-to-table.c
+++ b/blind/index-to-table.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/listhead.c
+++ b/blind/listhead.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/liststruc.c
+++ b/blind/liststruc.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/local-index.c
+++ b/blind/local-index.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/lsfile.c
+++ b/blind/lsfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/lsfile.h
+++ b/blind/lsfile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/matchfile.c
+++ b/blind/matchfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/matchobj.c
+++ b/blind/matchobj.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/merge-index-main.c
+++ b/blind/merge-index-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/merge-index.c
+++ b/blind/merge-index.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/mergesolved.c
+++ b/blind/mergesolved.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/modhead.c
+++ b/blind/modhead.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/new-wcs-main.c
+++ b/blind/new-wcs-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/new-wcs.c
+++ b/blind/new-wcs.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/noise.h
+++ b/blind/noise.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plot-constellations.c
+++ b/blind/plot-constellations.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plot-xy-and-quad.c
+++ b/blind/plot-xy-and-quad.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotannotations.c
+++ b/blind/plotannotations.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotcoadd.c
+++ b/blind/plotcoadd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotcoadd.h
+++ b/blind/plotcoadd.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotfill.c
+++ b/blind/plotfill.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotgrid.c
+++ b/blind/plotgrid.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plothealpix.c
+++ b/blind/plothealpix.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotimage.c
+++ b/blind/plotimage.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotindex.c
+++ b/blind/plotindex.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotmatch.c
+++ b/blind/plotmatch.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotoutline.c
+++ b/blind/plotoutline.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotquad.c
+++ b/blind/plotquad.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotradec.c
+++ b/blind/plotradec.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotstuff-main.c
+++ b/blind/plotstuff-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotstuff.c
+++ b/blind/plotstuff.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotxxx.c
+++ b/blind/plotxxx.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotxxx.h
+++ b/blind/plotxxx.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotxy-main.c
+++ b/blind/plotxy-main.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/plotxy.c
+++ b/blind/plotxy.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/pquad.h
+++ b/blind/pquad.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/printsolved.c
+++ b/blind/printsolved.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quad-builder.c
+++ b/blind/quad-builder.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quad-utils.c
+++ b/blind/quad-utils.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quadcenters.c
+++ b/blind/quadcenters.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quadidx.c
+++ b/blind/quadidx.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quadscales.c
+++ b/blind/quadscales.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/quadsperstar.c
+++ b/blind/quadsperstar.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/randcat.c
+++ b/blind/randcat.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/rdls2hpls.c
+++ b/blind/rdls2hpls.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/rdlstohealpix.c
+++ b/blind/rdlstohealpix.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/resort-xylist-main.c
+++ b/blind/resort-xylist-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/resort-xylist.c
+++ b/blind/resort-xylist.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/solve-field.c
+++ b/blind/solve-field.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/solvedclient.c
+++ b/blind/solvedclient.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/solvedfile.c
+++ b/blind/solvedfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/solvedserver.c
+++ b/blind/solvedserver.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/solver.c
+++ b/blind/solver.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/spike_join.c
+++ b/blind/spike_join.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/startree.c
+++ b/blind/startree.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/startree2-main.c
+++ b/blind/startree2-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/startree2.c
+++ b/blind/startree2.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/startree2.h
+++ b/blind/startree2.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/startree2rdls.c
+++ b/blind/startree2rdls.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/subwcs.c
+++ b/blind/subwcs.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/tablist.c
+++ b/blind/tablist.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/tabmerge.c
+++ b/blind/tabmerge.c
@@ -17,7 +17,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/test-solver-2.c
+++ b/blind/test-solver-2.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/test-solver.c
+++ b/blind/test-solver.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/tweak-main.c
+++ b/blind/tweak-main.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/tweak.c
+++ b/blind/tweak.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/tweak2.c
+++ b/blind/tweak2.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/uniformize-catalog-main.c
+++ b/blind/uniformize-catalog-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/uniformize-catalog.c
+++ b/blind/uniformize-catalog.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/unpermute-quads-main.c
+++ b/blind/unpermute-quads-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/unpermute-quads.c
+++ b/blind/unpermute-quads.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/unpermute-stars-main.c
+++ b/blind/unpermute-stars-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/unpermute-stars.c
+++ b/blind/unpermute-stars.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/verify-main.c
+++ b/blind/verify-main.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/verify-paths.c
+++ b/blind/verify-paths.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/verify.c
+++ b/blind/verify.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/verify2.c
+++ b/blind/verify2.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/verify2.h
+++ b/blind/verify2.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/wcs-grab.c
+++ b/blind/wcs-grab.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/blind/whynot.c
+++ b/blind/whynot.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/2mass-fits.c
+++ b/catalogs/2mass-fits.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/2mass.c
+++ b/catalogs/2mass.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/2masstofits.c
+++ b/catalogs/2masstofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/brightstars.c
+++ b/catalogs/brightstars.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/build-hd-tree.c
+++ b/catalogs/build-hd-tree.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/constellations.c
+++ b/catalogs/constellations.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/grab-stellarium-constellations.c
+++ b/catalogs/grab-stellarium-constellations.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/hd.c
+++ b/catalogs/hd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ngc2000.c
+++ b/catalogs/ngc2000.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ngcic-accurate.c
+++ b/catalogs/ngcic-accurate.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/nomad-fits.c
+++ b/catalogs/nomad-fits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/nomad.c
+++ b/catalogs/nomad.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/nomadtofits.c
+++ b/catalogs/nomadtofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/read_nomad.c
+++ b/catalogs/read_nomad.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/tycho2-fits.c
+++ b/catalogs/tycho2-fits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/tycho2.c
+++ b/catalogs/tycho2.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/tycho2tofits.c
+++ b/catalogs/tycho2tofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/tycho2tostellarium.c
+++ b/catalogs/tycho2tostellarium.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac3-fits.c
+++ b/catalogs/ucac3-fits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac3-fits.h
+++ b/catalogs/ucac3-fits.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac3.c
+++ b/catalogs/ucac3.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac3tofits.c
+++ b/catalogs/ucac3tofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac4-fits.c
+++ b/catalogs/ucac4-fits.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac4-fits.h
+++ b/catalogs/ucac4-fits.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac4.c
+++ b/catalogs/ucac4.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/ucac4tofits.c
+++ b/catalogs/ucac4tofits.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/usnob-fits.c
+++ b/catalogs/usnob-fits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/usnob-scamp-catalog.c
+++ b/catalogs/usnob-scamp-catalog.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/usnob.c
+++ b/catalogs/usnob.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/catalogs/usnobtofits.c
+++ b/catalogs/usnobtofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/doc/UCAC3_guide/build-index.py
+++ b/doc/UCAC3_guide/build-index.py
@@ -8,7 +8,8 @@
 
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/doc/UCAC3_guide/get_ucac3.py
+++ b/doc/UCAC3_guide/get_ucac3.py
@@ -7,7 +7,8 @@
 
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/doc/UCAC4_guide/build-index.py
+++ b/doc/UCAC4_guide/build-index.py
@@ -6,7 +6,8 @@
 # Copyright 2014 Denis Vida.
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU

--- a/doc/UCAC4_guide/get_ucac4.py
+++ b/doc/UCAC4_guide/get_ucac4.py
@@ -6,7 +6,8 @@
 # Copyright 2014 Denis Vida.
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU

--- a/include/astrometry/2mass-fits.h
+++ b/include/astrometry/2mass-fits.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/2mass.h
+++ b/include/astrometry/2mass.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/allquads.h
+++ b/include/astrometry/allquads.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/an-bool.h
+++ b/include/astrometry/an-bool.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/an-endian.h
+++ b/include/astrometry/an-endian.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/an-opts.h
+++ b/include/astrometry/an-opts.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/an-thread-pthreads.h
+++ b/include/astrometry/an-thread-pthreads.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/an-thread.h
+++ b/include/astrometry/an-thread.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/anwcs.h
+++ b/include/astrometry/anwcs.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/augment-xylist.h
+++ b/include/astrometry/augment-xylist.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/axyfile.h
+++ b/include/astrometry/axyfile.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bl-nl.h
+++ b/include/astrometry/bl-nl.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bl-nl.inc
+++ b/include/astrometry/bl-nl.inc
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bl-sort.h
+++ b/include/astrometry/bl-sort.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bl.h
+++ b/include/astrometry/bl.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bl.inc
+++ b/include/astrometry/bl.inc
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/blind.h
+++ b/include/astrometry/blind.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/blindutils.h
+++ b/include/astrometry/blindutils.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/brightstars.h
+++ b/include/astrometry/brightstars.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/bt.h
+++ b/include/astrometry/bt.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/build-index.h
+++ b/include/astrometry/build-index.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/cairoutils.h
+++ b/include/astrometry/cairoutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/catalog.h
+++ b/include/astrometry/catalog.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/codefile.h
+++ b/include/astrometry/codefile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/codekd.h
+++ b/include/astrometry/codekd.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/codetree.h
+++ b/include/astrometry/codetree.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/constellations.h
+++ b/include/astrometry/constellations.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/convolve-image.h
+++ b/include/astrometry/convolve-image.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/datalog.h
+++ b/include/astrometry/datalog.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/dimage.h
+++ b/include/astrometry/dimage.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty

--- a/include/astrometry/dualtree.h
+++ b/include/astrometry/dualtree.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/dualtree_nearestneighbour.h
+++ b/include/astrometry/dualtree_nearestneighbour.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/dualtree_rangesearch.h
+++ b/include/astrometry/dualtree_rangesearch.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/engine.h
+++ b/include/astrometry/engine.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/errors.h
+++ b/include/astrometry/errors.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fileutils.h
+++ b/include/astrometry/fileutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fit-wcs.h
+++ b/include/astrometry/fit-wcs.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fits-guess-scale.h
+++ b/include/astrometry/fits-guess-scale.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fitsbin.h
+++ b/include/astrometry/fitsbin.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fitsfile.h
+++ b/include/astrometry/fitsfile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fitsioutils.h
+++ b/include/astrometry/fitsioutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/fitstable.h
+++ b/include/astrometry/fitstable.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/gslutils.h
+++ b/include/astrometry/gslutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/hd.h
+++ b/include/astrometry/hd.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/healpix-utils.h
+++ b/include/astrometry/healpix-utils.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/healpix.h
+++ b/include/astrometry/healpix.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/hpquads.h
+++ b/include/astrometry/hpquads.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/image2xy-files.h
+++ b/include/astrometry/image2xy-files.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/image2xy.h
+++ b/include/astrometry/image2xy.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/index.h
+++ b/include/astrometry/index.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/intmap.h
+++ b/include/astrometry/intmap.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/ioutils.h
+++ b/include/astrometry/ioutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/kdtree.h
+++ b/include/astrometry/kdtree.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/kdtree_fits_io.h
+++ b/include/astrometry/kdtree_fits_io.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/keywords.h
+++ b/include/astrometry/keywords.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/matchfile.h
+++ b/include/astrometry/matchfile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/matchobj.h
+++ b/include/astrometry/matchobj.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/mathutil.h
+++ b/include/astrometry/mathutil.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/mathutil.inc
+++ b/include/astrometry/mathutil.inc
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/merge-index.h
+++ b/include/astrometry/merge-index.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/multiindex.h
+++ b/include/astrometry/multiindex.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/new-wcs.h
+++ b/include/astrometry/new-wcs.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/ngc2000.h
+++ b/include/astrometry/ngc2000.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/ngcic-accurate.h
+++ b/include/astrometry/ngcic-accurate.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/nomad-fits.h
+++ b/include/astrometry/nomad-fits.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/nomad.h
+++ b/include/astrometry/nomad.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/os-features.h
+++ b/include/astrometry/os-features.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/permutedsort.h
+++ b/include/astrometry/permutedsort.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotfill.h
+++ b/include/astrometry/plotfill.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotgrid.h
+++ b/include/astrometry/plotgrid.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plothealpix.h
+++ b/include/astrometry/plothealpix.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotindex.h
+++ b/include/astrometry/plotindex.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotmatch.h
+++ b/include/astrometry/plotmatch.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotoutline.h
+++ b/include/astrometry/plotoutline.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotradec.h
+++ b/include/astrometry/plotradec.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotstuff.h
+++ b/include/astrometry/plotstuff.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/plotxy.h
+++ b/include/astrometry/plotxy.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/qidxfile.h
+++ b/include/astrometry/qidxfile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/quad-builder.h
+++ b/include/astrometry/quad-builder.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/quad-utils.h
+++ b/include/astrometry/quad-utils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/quadfile.h
+++ b/include/astrometry/quadfile.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/rdlist.h
+++ b/include/astrometry/rdlist.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/resample.h
+++ b/include/astrometry/resample.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/resort-xylist.h
+++ b/include/astrometry/resort-xylist.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/scamp-catalog.h
+++ b/include/astrometry/scamp-catalog.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/scamp.h
+++ b/include/astrometry/scamp.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/simplexy-common.h
+++ b/include/astrometry/simplexy-common.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/simplexy.h
+++ b/include/astrometry/simplexy.h
@@ -5,7 +5,8 @@
  
  The Astrometry.net suite is free software; you can redistribute it
  and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty

--- a/include/astrometry/sip-utils.h
+++ b/include/astrometry/sip-utils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/sip.h
+++ b/include/astrometry/sip.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/sip_qfits.h
+++ b/include/astrometry/sip_qfits.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/solvedclient.h
+++ b/include/astrometry/solvedclient.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/solvedfile.h
+++ b/include/astrometry/solvedfile.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/solver.h
+++ b/include/astrometry/solver.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/starkd.h
+++ b/include/astrometry/starkd.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/starutil.h
+++ b/include/astrometry/starutil.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/starutil.inc
+++ b/include/astrometry/starutil.inc
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/starxy.h
+++ b/include/astrometry/starxy.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tabsort.h
+++ b/include/astrometry/tabsort.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tic.h
+++ b/include/astrometry/tic.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tpv.h
+++ b/include/astrometry/tpv.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tweak.h
+++ b/include/astrometry/tweak.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tweak2.h
+++ b/include/astrometry/tweak2.h
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tycho2-fits.h
+++ b/include/astrometry/tycho2-fits.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/tycho2.h
+++ b/include/astrometry/tycho2.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/ucac3.h
+++ b/include/astrometry/ucac3.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/ucac4.h
+++ b/include/astrometry/ucac4.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/uniformize-catalog.h
+++ b/include/astrometry/uniformize-catalog.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/unpermute-quads.h
+++ b/include/astrometry/unpermute-quads.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/unpermute-stars.h
+++ b/include/astrometry/unpermute-stars.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/usnob-fits.h
+++ b/include/astrometry/usnob-fits.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/usnob.h
+++ b/include/astrometry/usnob.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/verify.h
+++ b/include/astrometry/verify.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/wcs-rd2xy.h
+++ b/include/astrometry/wcs-rd2xy.h
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/wcs-xy2rd.h
+++ b/include/astrometry/wcs-xy2rd.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/include/astrometry/xylist.h
+++ b/include/astrometry/xylist.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/checktree.c
+++ b/libkd/checktree.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/dualtree.c
+++ b/libkd/dualtree.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/dualtree_nearestneighbour.c
+++ b/libkd/dualtree_nearestneighbour.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/dualtree_rangesearch.c
+++ b/libkd/dualtree_rangesearch.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/fix-bb.c
+++ b/libkd/fix-bb.c
@@ -4,7 +4,8 @@
 
  libkd is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
- the Free Software Foundation, version 2.
+ the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
  libkd is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ddd.c
+++ b/libkd/kdint_ddd.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dds.c
+++ b/libkd/kdint_dds.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ddu.c
+++ b/libkd/kdint_ddu.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dss.c
+++ b/libkd/kdint_dss.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dtype_d.h
+++ b/libkd/kdint_dtype_d.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dtype_f.h
+++ b/libkd/kdint_dtype_f.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dtype_s.h
+++ b/libkd/kdint_dtype_s.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_dtype_u.h
+++ b/libkd/kdint_dtype_u.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_duu.c
+++ b/libkd/kdint_duu.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_etype_d.h
+++ b/libkd/kdint_etype_d.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_etype_f.h
+++ b/libkd/kdint_etype_f.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_etype_s.h
+++ b/libkd/kdint_etype_s.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_etype_u.h
+++ b/libkd/kdint_etype_u.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_fff.c
+++ b/libkd/kdint_fff.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ttype_d.h
+++ b/libkd/kdint_ttype_d.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ttype_f.h
+++ b/libkd/kdint_ttype_f.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ttype_s.h
+++ b/libkd/kdint_ttype_s.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdint_ttype_u.h
+++ b/libkd/kdint_ttype_u.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree.c
+++ b/libkd/kdtree.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_dim.c
+++ b/libkd/kdtree_dim.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_fits_io.c
+++ b/libkd/kdtree_fits_io.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal.c
+++ b/libkd/kdtree_internal.c
@@ -5,7 +5,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal.h
+++ b/libkd/kdtree_internal.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal_common.h
+++ b/libkd/kdtree_internal_common.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal_dists.c
+++ b/libkd/kdtree_internal_dists.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal_dualtree.c
+++ b/libkd/kdtree_internal_dualtree.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_internal_fits.c
+++ b/libkd/kdtree_internal_fits.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_mem.c
+++ b/libkd/kdtree_mem.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/kdtree_mem.h
+++ b/libkd/kdtree_mem.h
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/pyspherematch.c
+++ b/libkd/pyspherematch.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/qptst.c
+++ b/libkd/qptst.c
@@ -4,7 +4,8 @@
 
   libkd is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 2.
+  the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   libkd is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/test_dualtree_nn.c
+++ b/libkd/test_dualtree_nn.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/test_libkd.c
+++ b/libkd/test_libkd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/test_libkd_common.c
+++ b/libkd/test_libkd_common.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libkd/test_libkd_io.c
+++ b/libkd/test_libkd_io.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/an-endian.c
+++ b/util/an-endian.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/an-fitstopnm.c
+++ b/util/an-fitstopnm.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/an-opts.c
+++ b/util/an-opts.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/an-pnmtofits.c
+++ b/util/an-pnmtofits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/anwcs.c
+++ b/util/anwcs.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/bl-nl.c
+++ b/util/bl-nl.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/bl-sort.c
+++ b/util/bl-sort.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/bl.c
+++ b/util/bl.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/boilerplate.h
+++ b/util/boilerplate.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/bt.c
+++ b/util/bt.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/cairoutils.c
+++ b/util/cairoutils.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/cfitsutils.h
+++ b/util/cfitsutils.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/codekd.c
+++ b/util/codekd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/convolve-image.c
+++ b/util/convolve-image.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dallpeaks.c
+++ b/util/dallpeaks.c
@@ -5,7 +5,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dallpeaks.inc
+++ b/util/dallpeaks.inc
@@ -6,7 +6,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/datalog.c
+++ b/util/datalog.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dcen3x3.c
+++ b/util/dcen3x3.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute it
   and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty

--- a/util/dfind.c
+++ b/util/dfind.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dfind2.c
+++ b/util/dfind2.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dmedsmooth.c
+++ b/util/dmedsmooth.c
@@ -6,7 +6,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dobjects.c
+++ b/util/dobjects.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/downsample-fits.c
+++ b/util/downsample-fits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dpeaks.c
+++ b/util/dpeaks.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dselip.c
+++ b/util/dselip.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dsigma.c
+++ b/util/dsigma.c
@@ -6,7 +6,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dsigma.inc
+++ b/util/dsigma.inc
@@ -6,7 +6,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dsmooth.c
+++ b/util/dsmooth.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/dsmooth.inc
+++ b/util/dsmooth.inc
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/errors.c
+++ b/util/errors.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fit-wcs.c
+++ b/util/fit-wcs.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fits-column-merge.c
+++ b/util/fits-column-merge.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fits-flip-endian.c
+++ b/util/fits-flip-endian.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fitsbin.c
+++ b/util/fitsbin.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fitsfile.c
+++ b/util/fitsfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fitsgetext.c
+++ b/util/fitsgetext.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fitsioutils.c
+++ b/util/fitsioutils.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/fitstable.c
+++ b/util/fitstable.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/get-healpix.c
+++ b/util/get-healpix.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/gslutils.c
+++ b/util/gslutils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/healpix-diagram.py
+++ b/util/healpix-diagram.py
@@ -3,7 +3,8 @@
 #
 # The Astrometry.net suite is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation, version 2.
+# as published by the Free Software Foundation; either version 2, or
+# (at your option) any later version.
 #
 # The Astrometry.net suite is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/healpix-utils.c
+++ b/util/healpix-utils.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/healpix.c
+++ b/util/healpix.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/histogram.c
+++ b/util/histogram.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/histogram.h
+++ b/util/histogram.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/histogram2d.c
+++ b/util/histogram2d.c
@@ -4,7 +4,8 @@
  
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/histogram2d.h
+++ b/util/histogram2d.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/hpsplit.c
+++ b/util/hpsplit.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/image2xy.c
+++ b/util/image2xy.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/index.c
+++ b/util/index.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/intmap.c
+++ b/util/intmap.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/ioutils.c
+++ b/util/ioutils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/jpl.h
+++ b/util/jpl.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/log.c
+++ b/util/log.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/mathutil.c
+++ b/util/mathutil.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/multiindex.c
+++ b/util/multiindex.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/os-features-test.c
+++ b/util/os-features-test.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/os-features.c
+++ b/util/os-features.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/pad-file.c
+++ b/util/pad-file.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/permutedsort.c
+++ b/util/permutedsort.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/qidxfile.c
+++ b/util/qidxfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/quadfile.c
+++ b/util/quadfile.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/query-starkd.c
+++ b/util/query-starkd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/rdlist.c
+++ b/util/rdlist.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/resample.c
+++ b/util/resample.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/resample.inc
+++ b/util/resample.inc
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/scamp-catalog.c
+++ b/util/scamp-catalog.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/scamp.c
+++ b/util/scamp.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/search-index.c
+++ b/util/search-index.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/simplexy.c
+++ b/util/simplexy.c
@@ -6,7 +6,8 @@
 
  The Astrometry.net suite is free software; you can redistribute it
  and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty

--- a/util/sip-utils.c
+++ b/util/sip-utils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/sip.c
+++ b/util/sip.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/sip_qfits.c
+++ b/util/sip_qfits.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/sparsematrix.c
+++ b/util/sparsematrix.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/sparsematrix.h
+++ b/util/sparsematrix.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/starkd.c
+++ b/util/starkd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/starutil.c
+++ b/util/starutil.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/starxy.c
+++ b/util/starxy.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/subtable.c
+++ b/util/subtable.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/tabsort-main.c
+++ b/util/tabsort-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/tabsort.c
+++ b/util/tabsort.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_anwcs.c
+++ b/util/test_anwcs.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_bl.c
+++ b/util/test_bl.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_bt.c
+++ b/util/test_bt.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_convolve_image.c
+++ b/util/test_convolve_image.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_ctmf.c
+++ b/util/test_ctmf.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_dcen3x3.c
+++ b/util/test_dcen3x3.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_dfind.c
+++ b/util/test_dfind.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_dsmooth.c
+++ b/util/test_dsmooth.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_fitsioutils.c
+++ b/util/test_fitsioutils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_healpix.c
+++ b/util/test_healpix.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_ioutils.c
+++ b/util/test_ioutils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_jpl.c
+++ b/util/test_jpl.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_scamp_catalog.c
+++ b/util/test_scamp_catalog.c
@@ -4,7 +4,8 @@
 
  The Astrometry.net suite is free software; you can redistribute
  it and/or modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation, version 2.
+ as published by the Free Software Foundation; either version 2, or
+ (at your option) any later version.
 
  The Astrometry.net suite is distributed in the hope that it will be
  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_simplexy.c
+++ b/util/test_simplexy.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_sip-utils.c
+++ b/util/test_sip-utils.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_starutil.c
+++ b/util/test_starutil.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/test_svd.c
+++ b/util/test_svd.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/tic.c
+++ b/util/tic.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/tpv.c
+++ b/util/tpv.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-pv2sip.c
+++ b/util/wcs-pv2sip.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-rd2xy-main.c
+++ b/util/wcs-rd2xy-main.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-rd2xy.c
+++ b/util/wcs-rd2xy.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-resample-main.c
+++ b/util/wcs-resample-main.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-resample.c
+++ b/util/wcs-resample.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-resample.h
+++ b/util/wcs-resample.h
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-xy2rd-main.c
+++ b/util/wcs-xy2rd-main.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcs-xy2rd.c
+++ b/util/wcs-xy2rd.c
@@ -5,7 +5,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/wcsinfo.c
+++ b/util/wcsinfo.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/util/xylist.c
+++ b/util/xylist.c
@@ -4,7 +4,8 @@
 
   The Astrometry.net suite is free software; you can redistribute
   it and/or modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation, version 2.
+  as published by the Free Software Foundation; either version 2, or
+  (at your option) any later version.
 
   The Astrometry.net suite is distributed in the hope that it will be
   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
This is a proposal to change the license text from
```
The Astrometry.net suite is free software; you can redistribute
it and/or modify it under the terms of the GNU General Public License
as published by the Free Software Foundation, version 2.
```
to
```
The Astrometry.net suite is free software; you can redistribute
it and/or modify it under the terms of the GNU General Public License
as published by the Free Software Foundation; either version 2, or
(at your option) any later version.
```
This will make the files compatible to the GSL license (which is GPL-3), and therefore allows linking with the GSL (resp. the `an-gsl` that is provided with the source).