### PR TITLE
Use $(LIB_INSTALL_DIR) instead of $(INSTALL_DIR)/lib

### DIFF
--- a/blind/Makefile
+++ b/blind/Makefile
@@ -244,10 +244,10 @@ install: $(INSTALL_EXECS) $(INSTALL_LIB)
 		echo cp '$(INCLUDE_DIR)/'$$x '$(INCLUDE_INSTALL_DIR)'; \
 		cp '$(INCLUDE_DIR)/'$$x '$(INCLUDE_INSTALL_DIR)'; \
 	done
-	mkdir -p '$(INSTALL_DIR)/lib'
+	mkdir -p '$(LIB_INSTALL_DIR)'
 	@for x in $(INSTALL_LIB); do \
-		echo cp $$x '$(INSTALL_DIR)/lib'; \
-		cp $$x '$(INSTALL_DIR)/lib'; \
+		echo cp $$x '$(LIB_INSTALL_DIR)'; \
+		cp $$x '$(LIB_INSTALL_DIR)'; \
 	done
 	mkdir -p '$(PY_INSTALL_DIR)'
 	@for x in $(PYTHON_INSTALL); do \

--- a/libkd/Makefile
+++ b/libkd/Makefile
@@ -144,10 +144,10 @@ install: $(LIBKD_INSTALL) $(LIBKD)
 		echo cp '$(INCLUDE_DIR)/'$$x '$(INCLUDE_INSTALL_DIR)'; \
 		cp '$(INCLUDE_DIR)/'$$x '$(INCLUDE_INSTALL_DIR)'; \
 	done
-	mkdir -p '$(INSTALL_DIR)/lib'
+	mkdir -p '$(LIB_INSTALL_DIR)'
 	@for x in $(LIBKD); do \
-		echo cp $$x '$(INSTALL_DIR)/lib'; \
-		cp $$x '$(INSTALL_DIR)/lib'; \
+		echo cp $$x '$(LIB_INSTALL_DIR)'; \
+		cp $$x '$(LIB_INSTALL_DIR)'; \
 	done
 	-$(MAKE) install-spherematch
 


### PR DESCRIPTION
For Debian, I need to setup a special library installation directory
```
LIB_INSTALL_DIR=/usr/lib/${DEB_HOST_MULTIARCH}/
```
to enable multiarch support.
This variable was already created in `util/makefile.common`, but not used. This pull request enables using the variable.