### PR TITLE
Added option to disable march=native, required for packaging @Linux d…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@
 # is to turn optimization on.  See util/makefile.common for details.
 #export OPTIMIZE = no
 
+# Build package for a Linux disribution? Then -march=native has to be
+# disabled, otherwise the package won't work on all machines.
+# Comment out the following line to disable native flag, default is yes
+#export MARCH_NATIVE = no 
+
 all:
 
 BASEDIR := .

--- a/util/makefile.common
+++ b/util/makefile.common
@@ -154,8 +154,12 @@ ifneq ($(origin ARCH_FLAGS),undefined)
 else
   # Try to guess some good compiler flags for this CPU.
 
-  # Use -march=native if it's available (gcc 4.2 and above)
-  ARG := -march=native
+  # Use -march=native if it's available (gcc 4.2 and above) and if we are not packaging 
+  # for a distribution
+  MARCH_NATIVE ?= yes
+  ifeq ($(MARCH_NATIVE),yes)
+    ARG := -march=native
+  endif
   X := $(shell $(CCTEST))
   ifneq ($(X),)
     FLAGS_DEF += $(X)


### PR DESCRIPTION
By default the march=native compiler flag is used. This makes it difficult to produce usable packages for Linux distributions as the created binaries will not work on all cpus. I added a variable MARCH_NATIVE which can be set to disable the default behaviour (which I did not change) to Makefile and util/makefile.common.