### PR TITLE
more generic NETPBM include path, required on fi. Ubuntu

### DIFF
--- a/util/an-pnmtofits.c
+++ b/util/an-pnmtofits.c
@@ -9,7 +9,7 @@
 #include "os-features-config.h" // for HAVE_NETPBM.
 
 #if HAVE_NETPBM
-#include <netpbm/pam.h>
+#include <pam.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/util/cairoutils.c
+++ b/util/cairoutils.c
@@ -18,7 +18,7 @@
 #include "os-features.h"
 
 #if HAVE_NETPBM
-#include <netpbm/ppm.h>
+#include <ppm.h>
 #endif
 
 #include "ioutils.h"

--- a/util/os-features-test.c
+++ b/util/os-features-test.c
@@ -72,7 +72,7 @@ int main() {
 #endif
 
 #if defined(TEST_NETPBM) || defined(TEST_NETPBM_MAKE)
-#include <netpbm/pam.h>
+#include <pam.h>
 int main(int argc, char** args) {
 	struct pam img;
 	pm_init(args[0], 0);


### PR DESCRIPTION
On fi. Ubuntu the libnetpbm10-dev package brings pam.h at `/usr/include/pam.h`
The astrometry code addresses pam.h as `<netpbm/pam.h>` which will thus never be found on stock Ubuntu.
Therefore I propose to include `<pam.h>` from now on and add an include search path for other systems like `/usr/include/netpbm` (if that exists anywhere).
I hope this makes sense.
With this 3 line patch astrometry compiles clean on Ubuntu 14.04.
-- Hans
