### PR TITLE
Set path to python interpreter in Makefile

### DIFF
--- a/blind/Makefile
+++ b/blind/Makefile
@@ -225,7 +225,7 @@ install: $(INSTALL_EXECS) $(INSTALL_LIB)
 		cp $$x '$(INSTALL_DIR)/bin'; \
 	done
 	mkdir -p '$(ETC_INSTALL_DIR)'
-	python -c "import os; print open('../etc/astrometry.cfg-dist').read().replace('DATA_INSTALL_DIR', '$(DATA_FINAL_DIR)')" > '$(ETC_INSTALL_DIR)/astrometry.cfg'
+	$(PYTHON) -c "import os; print open('../etc/astrometry.cfg-dist').read().replace('DATA_INSTALL_DIR', '$(DATA_FINAL_DIR)')" > '$(ETC_INSTALL_DIR)/astrometry.cfg'
 	mkdir -p '$(INCLUDE_INSTALL_DIR)'
 	@for x in $(INSTALL_H); do \
 		echo cp '$(INCLUDE_DIR)/'$$x '$(INCLUDE_INSTALL_DIR)'; \
@@ -406,14 +406,14 @@ _plotstuff_c$(PYTHON_SO_EXT): plotstuff.i $(PLOTSTUFF) $(CATS_LIB) $(CAIRO_SLIB)
 	INC="$(ANFILES_INC) $(CAIRO_INC) $(NETPBM_INC)" \
 	CFLAGS_SWIG="$(ANFILES_CFLAGS)" \
 	CFLAGS="$(CFLAGS)" \
-	python setup.py build_ext -v --inplace --build-temp .
+	$(PYTHON) setup.py build_ext -v --inplace --build-temp .
 
 _blind$(PYTHON_SO_EXT): blind.i $(ENGINE_OBJS)
 	LDFLAGS="$(LDFLAGS)" LDLIBS="$(LDLIBS)" \
 	SLIB="$(SLIB)" \
 	INC="$(ANFILES_INC)" \
 	CFLAGS="$(ANFILES_CFLAGS)" \
-	python setup-blind.py build_ext -v --inplace --build-temp .
+	$(PYTHON) setup-blind.py build_ext -v --inplace --build-temp .
 
 test_plotstuff-main.c: test_plotstuff.c
 	$(AN_SHELL) $(MAKE_TESTS) $^ > $@

--- a/libkd/Makefile
+++ b/libkd/Makefile
@@ -94,16 +94,16 @@ spherematch_c$(PYTHON_SO_EXT): pyspherematch.c setup.py $(SLIB)
 	SLIB="$(SLIB)" \
 	INC="$(INC)" \
 	CFLAGS="$(CFLAGS)" \
-	python setup.py build_ext --inplace --force --build-temp .
+	$(PYTHON) setup.py build_ext --inplace --force --build-temp .
 
 # pyspherematch.c includes Python.h -- so have to make sure to add Python.h include path
 # (otherwise, get an obscure message from numpy about needing a python built with unicode)
 ifeq ($(MAKECMDGOALS),spherematch_c$(PYTHON_SO_EXT))
-  CFLAGS += $(shell python -c "from distutils.sysconfig import *; print '-I'+get_python_inc()")
+  CFLAGS += $(shell $(PYTHON) -c "from distutils.sysconfig import *; print '-I'+get_python_inc()")
   DEP_OBJ += $(PYSPHEREMATCH_OBJ)
 endif
 ifeq ($(MAKECMDGOALS),pyspherematch)
-  CFLAGS += $(shell python -c "from distutils.sysconfig import *; print '-I'+get_python_inc()")
+  CFLAGS += $(shell $(PYTHON) -c "from distutils.sysconfig import *; print '-I'+get_python_inc()")
   DEP_OBJ += $(PYSPHEREMATCH_OBJ)
 endif
 

--- a/libkd/Makefile.min
+++ b/libkd/Makefile.min
@@ -40,7 +40,7 @@ libkd-min.a: $(DT) $(KD_FITS) $(KD) $(INTERNALS) $(QFITSO) $(UTILO)
 
 spherematch_c.so: pyspherematch.c setup-min.py libkd-min.a
 	INC="$(INC)" CFLAGS="$(CFLAGS)" \
-	python setup-min.py build_ext --inplace --build-temp . --force
+	$(PYTHON) setup-min.py build_ext --inplace --build-temp . --force
 
 ALL_TEST_FILES := test_dualtree_nn test_libkd test_libkd_io
 

--- a/sdss/Makefile
+++ b/sdss/Makefile
@@ -21,7 +21,7 @@ lib: _cutils$(PYTHON_SO_EXT) cutils.py
 MY_DIR := $(PY_BASE_INSTALL_DIR)/sdss
 
 _cutils$(PYTHON_SO_EXT) cutils.py: cutils.i
-	python setup.py build_ext -v --inplace --build-temp .
+	$(PYTHON) setup.py build_ext -v --inplace --build-temp .
 
 INSTALL_PY := __init__.py common.py cutout.py dr7.py dr8.py runList-dr8.par \
 	dr9.py fields.py cutout.py runList-dr9.par dr10.py runList-dr10.par \

--- a/util/Makefile
+++ b/util/Makefile
@@ -166,11 +166,11 @@ ALL_OBJ += wcs-pv2sip.o
 _util$(PYTHON_SO_EXT): util.i lanczos.i $(ANFILES_SLIB)
 	LDFLAGS="$(LDFLAGS)" LDLIBS="$(LDLIBS)" SLIB="$(ANFILES_SLIB)" \
 	INC="$(ANFILES_INC)" CFLAGS="$(CFLAGS)" \
-	python setup.py build_ext -v --inplace --build-temp .
+	$(PYTHON) setup.py build_ext -v --inplace --build-temp .
 util.py: util.i lanczos.i
 	LDFLAGS="$(LDFLAGS)" LDLIBS="$(LDLIBS)" SLIB="$(ANFILES_SLIB)" \
 	INC="$(ANFILES_INC)" CFLAGS="$(CFLAGS)" \
-	python setup.py build_ext -v --inplace --build-temp .
+	$(PYTHON) setup.py build_ext -v --inplace --build-temp .
 
 PYUTIL := _util$(PYTHON_SO_EXT) util.py
 pyutil: $(PYUTIL)

--- a/util/makefile.common
+++ b/util/makefile.common
@@ -4,6 +4,7 @@
 INCLUDE_BASE_DIR := $(BASEDIR)/include
 INCLUDE_DIR := $(INCLUDE_BASE_DIR)/astrometry
 
+PYTHON ?= python
 INSTALL_DIR ?= /usr/local/astrometry
 # Put INSTALL_DIR in the environment of commands run by Make.
 export INSTALL_DIR
@@ -109,7 +110,7 @@ ifneq (CYGWIN,$(findstring CYGWIN,$(UNAME)))
 endif 
 
 # Get the library suffix used by python distutils (.dll on cygwin, .so elsewhere)
-PYTHON_SO_EXT ?= $(shell python -c "from distutils import sysconfig; print sysconfig.get_config_var('SO')")
+PYTHON_SO_EXT ?= $(shell $(PYTHON) -c "from distutils import sysconfig; print sysconfig.get_config_var('SO')")
 # Set a default, otherwise terrible things happen:
 #   in util/Makefile : clean: rm -f *$(PYTHON_SO_EXT)
 ifeq ($(PYTHON_SO_EXT)x,x)


### PR DESCRIPTION
It is useful to modify the path to the python interpreter with a make variable for systems where the default python interpreter is python3.