### PR TITLE
Small doc changes to remove mention of `--no-fits2fits` (see #100)

### DIFF
--- a/doc/code.rst
+++ b/doc/code.rst
@@ -30,7 +30,6 @@ creates these "axy" files.
 * run *image2pnm.py* to uncompress and convert images to PNM.
 * for non-FITS images, run *ppmtopgm* and *an-pnmtofits* to produce FITS
 * run *image2xy* (or SourceExtractor) to generate list of (x,y) star coordinates (xylist)
-* for FITS files, run *fits2fits.py* to clean file
 * run *removelines.py* to remove lines of sources from the xylist
 * run *resort_xylist()* to sort by a combination of brightness and background
 * run *uniformize.py* to select a spatially uniform subset of stars

--- a/doc/oaq.rst
+++ b/doc/oaq.rst
@@ -12,7 +12,7 @@ A: Disable things that require numpy.
 
 Some parts of the code need the "numpy" python package.  To disable things that need numpy::
 
-    solve-field --no-fits2fits --no-remove-lines --uniformize 0  [....usual arguments...]
+    solve-field --no-remove-lines --uniformize 0  [....usual arguments...]
 
 
 Q: Is there a way to plot a grid of RA and Dec on the images?

--- a/doc/readme.rst
+++ b/doc/readme.rst
@@ -397,14 +397,6 @@ Tricks and Tips
     $ solve-field --downsample 4 ...
 
 
-* When solve-field processes FITS files, it runs them through a
-  "sanitizer" which tries to clean up non-standards-compliant images.
-  If your FITS files are compliant, this is a waste of time, and you can
-  avoid doing it::
-
-    $ solve-field --no-fits2fits ...
-
-
 * When solve-field processes FITS images, it looks for an existing
   WCS header.  If one is found, it tries to verify that header before
   trying to solve the image blindly.  You can prevent this with::
@@ -484,7 +476,7 @@ Tricks and Tips
 
   ::
 
-    $ solve-field input.xy --no-fits2fits --continue ...
+    $ solve-field input.xy --continue ...
 
   To skip previously solved inputs (note that this assumes single-HDU
   inputs)::

--- a/man/solve-field.1
+++ b/man/solve-field.1
@@ -191,9 +191,6 @@ sort using acompromise between background\-subtracted and non\-background\-subtr
 \fB\-6\fR, \fB\-\-extension\fR \fIint\fR
 FITS extension to read image from.
 .TP
-\fB\-2\fR, \fB\-\-no\-fits2fits\fR
-Don't sanitize FITS files; assume they're already valid
-.TP
 \fB\-\-invert\fR
 Invert the image (for black\-on\-white images)
 .TP


### PR DESCRIPTION
Just removing some of the leftover mentions of `--no-fits2fits`, which doesn't exist any more.