### PR TITLE
Changed uname directive from -a to -r due to non reproducible output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ tags:
 
 report:
 	-uname -m
-	-uname -o
+	-uname -r
 	-uname -p
 	-uname -s
 	@echo "CC is $(CC)"

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ tags:
 
 report:
 	-uname -m
-	-uname -a
+	-uname -o
 	-uname -p
 	-uname -s
 	@echo "CC is $(CC)"


### PR DESCRIPTION
Hello, I'm submitting this change in order to further the reproducible builds agenda - which aims to ensure all projects built remain bit-by-bit identical uniformly throughout the specified package.

In this case, the system call "uname -a" was generating some non deterministic output, which usually consists of time stamps and node names. A more detailed view can be found at the FreeBSD wiki: https://wiki.freebsd.org/ReproducibleBuilds (scroll down to find the link that contains diff's of all ports, including astronometry)

In summation, this change will allow this project to build in a reproducible fashion.
