### PR TITLE
added parity as option for file submission in client.py

### DIFF
--- a/net/client/client.py
+++ b/net/client/client.py
@@ -150,6 +150,7 @@ class Client(object):
                                 ('scale_err', None, float),
                                 ('center_ra', None, float),
                                 ('center_dec', None, float),
+                                ('parity',None,int),
                                 ('radius', None, float),
                                 ('downsample_factor', None, int),
                                 ('tweak_order', None, int),


### PR DESCRIPTION
The python example client.py did not accept the command line --parity flag. This was because the parity option is missing in the _get_upload_args method of Client. I added the option and now the --parity flag works.