### PR TITLE
Some updates to documentation

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -59,7 +59,7 @@ For example, in Debian 9 (Stretch)::
                            libbz2-dev swig libcfitsio-dev
 
 
-As of April 2019, the script doc/install_astrometry_on_linux.sh will install all dependencies along with astrometry.net on Linux
+As of April 2019, the script doc/install_astrometry_on_linux.sh will install all dependencies along with astrometry.net on Linux, and download 4200/ index files.
 
 
 CentOS 6.5 / Fedora / RedHat / RHEL -- Detailed Instructions:

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -5,8 +5,8 @@ Building/installing the Astrometry.net code
 
 Grab the code::
 
-   wget http://astrometry.net/downloads/astrometry.net-latest.tar.bz2
-   tar xjf astrometry.net-latest.tar.bz2
+   wget http://astrometry.net/downloads/astrometry.net-latest.tar.gz
+   tar xvzf astrometry.net-latest.tar.gz
    cd astrometry.net-*
 
 Build it.  The short version::
@@ -44,8 +44,9 @@ Ubuntu or Debian-like systems:
 
 ::
 
+
     $ sudo apt-get install libcairo2-dev libnetpbm10-dev netpbm \
-                           libpng12-dev libjpeg-dev python-numpy \
+                           libpng2-dev libjpeg-dev python-numpy \
                            python-pyfits python-dev zlib1g-dev \
                            libbz2-dev swig cfitsio-dev
 
@@ -56,6 +57,9 @@ For example, in Debian 9 (Stretch)::
                            libpng-dev libjpeg-dev python-numpy \
                            python-pyfits python-dev zlib1g-dev \
                            libbz2-dev swig libcfitsio-dev
+
+
+As of April 2019, the script doc/install_astrometry_on_linux.sh will install all dependencies along with astrometry.net on Linux
 
 
 CentOS 6.5 / Fedora / RedHat / RHEL -- Detailed Instructions:

--- a/doc/install_astrometry_on_linux.sh
+++ b/doc/install_astrometry_on_linux.sh
@@ -36,5 +36,4 @@ make CFITS_INC="-I$WORKSPACE_DIR/cfitsio/include" CFITS_LIB="-L$WORKSPACE_DIR/cf
 
 # download and install index files
 rm -rf /usr/local/astrometry/data/* && \
-wget -r -nd -P /usr/local/astrometry/data/ "data.astrometry.net/4200/"
-
+wget -r -nd -np -P /usr/local/astrometry/data/ "data.astrometry.net/4200/"

--- a/doc/install_astrometry_on_linux.sh
+++ b/doc/install_astrometry_on_linux.sh
@@ -1,30 +1,15 @@
 #!/bin/sh
-# TODO: a few of the commands require ‘yes/no’ answers, how to avoid this?
 
 WORKSPACE_DIR="/tmp"
 
-# basic linux install/build libs
+# basic linux install/build libs, python, and other support
 cd $WORKSPACE_DIR && \
-apt install make && \
+apt install -y make && \
 apt-get update && \
-apt-get install build-essential && \
-
-# python and other support
-apt-get install python python-pip netpbm zlib1g-dev libcairo2-dev libjpeg-dev && \
+apt-get install -y build-essential python python-pip netpbm zlib1g-dev libcairo2-dev libjpeg-dev libcfitsio-dev && \
 pip install numpy scipy pyfits && \
 
-# cfitsio
-cd $WORKSPACE_DIR && \
-rm -f cfitsio_latest.tar.gz* && \
-wget https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz && \
-tar xvzf cfitsio_latest.tar.gz && \
-cd cfitsio && \
-./configure && \
-make && \
-make install && \
-
 # astrometry
-cd $WORKSPACE_DIR && \
 rm -f astrometry.net-latest.tar.gz* && \
 wget http://astrometry.net/downloads/astrometry.net-latest.tar.gz && \
 tar xvzf astrometry.net-latest.tar.gz && \
@@ -36,4 +21,5 @@ make CFITS_INC="-I$WORKSPACE_DIR/cfitsio/include" CFITS_LIB="-L$WORKSPACE_DIR/cf
 
 # download and install index files
 rm -rf /usr/local/astrometry/data/* && \
-wget -r -nd -np -P /usr/local/astrometry/data/ "data.astrometry.net/4200/"
+wget -r -nd -np -P /usr/local/astrometry/data/ "data.astrometry.net/4100/" && \
+wget -r -nd -np -P /usr/local/astrometry/data/ "data.astrometry.net/5000/"

--- a/doc/install_astrometry_on_linux.sh
+++ b/doc/install_astrometry_on_linux.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# TODO: a few of the commands require ‘yes/no’ answers, how to avoid this?
+
+WORKSPACE_DIR="/tmp"
+
+# basic linux install/build libs
+cd $WORKSPACE_DIR && \
+apt install make && \
+apt-get update && \
+apt-get install build-essential && \
+
+# python and other support
+apt-get install python python-pip netpbm zlib1g-dev libcairo2-dev libjpeg-dev && \
+pip install numpy scipy pyfits && \
+
+# cfitsio
+cd $WORKSPACE_DIR && \
+rm -f cfitsio_latest.tar.gz* && \
+wget https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz && \
+tar xvzf cfitsio_latest.tar.gz && \
+cd cfitsio && \
+./configure && \
+make && \
+make install && \
+
+#apt-get install libcairo2-dev libjpeg-dev  && \
+
+# astrometry
+cd $WORKSPACE_DIR && \
+rm -f astrometry.net-latest.tar.gz* && \
+wget http://astrometry.net/downloads/astrometry.net-latest.tar.gz && \
+tar xvzf astrometry.net-latest.tar.gz && \
+cd astrometry.net-* && \
+make CFITS_INC="-I$WORKSPACE_DIR/cfitsio/include" CFITS_LIB="-L$WORKSPACE_DIR/cfitsio/lib -lcfitsio" && \
+make py && \
+make extra && \
+make CFITS_INC="-I$WORKSPACE_DIR/cfitsio/include" CFITS_LIB="-L$WORKSPACE_DIR/cfitsio/lib -lcfitsio" install && \
+
+# download and install index files
+rm -rf /usr/local/astrometry/data/* && \
+wget -r -nd -P /usr/local/astrometry/data/ "data.astrometry.net/4200/"
+

--- a/doc/install_astrometry_on_linux.sh
+++ b/doc/install_astrometry_on_linux.sh
@@ -23,8 +23,6 @@ cd cfitsio && \
 make && \
 make install && \
 
-#apt-get install libcairo2-dev libjpeg-dev  && \
-
 # astrometry
 cd $WORKSPACE_DIR && \
 rm -f astrometry.net-latest.tar.gz* && \


### PR DESCRIPTION
I added a script which takes care of installing all dependencies & astrometry on linux, and downloads the 4200/ files. The installation step takes ~15 minutes (with my 60mpbs connection), index files considerably longer.

Also fixed a couple lines in the docs which seemed to be stale.

Hopefully this is useful. Let me know if anything doesn't seem right, or possibly superfluous in the install script.