### PR TITLE
util/test_qsort.rc: Include <stdlib.h> for qsort_r

### DIFF
--- a/util/test_qsort_r.c
+++ b/util/test_qsort_r.c
@@ -3,6 +3,7 @@
  # Licensed under a 3-clause BSD style license - see LICENSE
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
qsort_r is typically declared in <stdlib.h>. Include this header file,
so that the test can be built using strict C99 compilers which do not
support implicit function declarations.