### PR TITLE
Filter out PCi_j keywords from FITS header

### DIFF
--- a/blind/new-wcs.c
+++ b/blind/new-wcs.c
@@ -28,6 +28,7 @@ static char* exclude_input[] = {
     "^CUNIT[12]$",
     "^CD[12]_[12]$",
     "^CDELT[12]$",
+    "^PC[12]_[12]$",
     // SIP
     "^[AB]P?_ORDER$",
     "^[AB]P?_[[:digit:]]_[[:digit:]]$",


### PR DESCRIPTION
This fixes #176 by filtering out the `PC` transform out of the old WCS. I've checked it locally but let me know if you want me to add a test to the code; I'll need you to point me towards the right folder/file.