### PR TITLE
create_temp_file() fixed

### DIFF
--- a/solver/augment-xylist.c
+++ b/solver/augment-xylist.c
@@ -46,7 +46,7 @@ static void delete_existing_an_headers(qfits_header* hdr);
 
 void augment_xylist_init(augment_xylist_t* axy) {
     memset(axy, 0, sizeof(augment_xylist_t));
-    axy->tempdir = "/tmp";
+    axy->tempdir = NULL;
     axy->tweak = TRUE;
     axy->tweakorder = 2;
     axy->depths = il_new(4);

--- a/util/ioutils.c
+++ b/util/ioutils.c
@@ -648,7 +648,7 @@ static char* get_temp_dir() {
 char* create_temp_file(const char* fn, const char* dir) {
     char* tempfile;
     int fid;
-    if (!dir || !strcmp(dir, "/tmp")) {
+    if (!dir) {
         dir = get_temp_dir();
     }
 

--- a/util/ioutils.c
+++ b/util/ioutils.c
@@ -648,7 +648,7 @@ static char* get_temp_dir() {
 char* create_temp_file(const char* fn, const char* dir) {
     char* tempfile;
     int fid;
-    if (!dir) {
+    if (!dir || !strcmp(dir, "/tmp")) {
         dir = get_temp_dir();
     }
 

--- a/util/test_anwcs.c
+++ b/util/test_anwcs.c
@@ -197,7 +197,7 @@ void test_wcslib_equals_tan(CuTest* tc) {
 #endif
     anwcs_t* anwcs = NULL;
     tan_t* tan;
-    char* tmpfile = create_temp_file("test-anwcs-wcs", "/tmp");
+    char* tmpfile = create_temp_file("test-anwcs-wcs", NULL);
     double x, y, x2, y2, ra, dec, ra2, dec2;
     int ok, ok2;
     int i;

--- a/util/test_ioutils.c
+++ b/util/test_ioutils.c
@@ -180,7 +180,7 @@ void test_run_command(CuTest* tc) {
     int trial;
     log_init(3);
 
-    tmpfn = create_temp_file("test_run_command", "/tmp");
+    tmpfn = create_temp_file("test_run_command", NULL);
     CuAssertPtrNotNull(tc, tmpfn);
 
     for (trial=0; trial<4; trial++) {

--- a/util/test_log.c
+++ b/util/test_log.c
@@ -61,8 +61,8 @@ void test_log_ts(CuTest* tc) {
     log_set_thread_specific();
     logmsg("Logging set thread specific.\n");
 
-    fn1 = create_temp_file("log", "/tmp");
-    fn2 = create_temp_file("log", "/tmp");
+    fn1 = create_temp_file("log", NULL);
+    fn2 = create_temp_file("log", NULL);
 
     logmsg("File 1 is %s\n", fn1);
     logmsg("File 2 is %s\n", fn2);

--- a/util/test_scamp_catalog.c
+++ b/util/test_scamp_catalog.c
@@ -11,7 +11,7 @@
 // This is really a demo, not a test.
 void test_scampcat_1(CuTest* tc) {
     qfits_header* hdr;
-    char* fn = create_temp_file("scampcat", "/tmp");
+    char* fn = create_temp_file("scampcat", NULL);
     printf("Creating scamp catalog: %s\n", fn);
     scamp_cat_t* scamp = scamp_catalog_open_for_writing(fn, FALSE);
     scamp_obj_t obj;
@@ -46,7 +46,7 @@ void test_scampcat_1(CuTest* tc) {
 // This is really a demo, not a test.
 void test_scampref_2(CuTest* tc) {
     qfits_header* hdr;
-    char* fn = create_temp_file("scampref", "/tmp");
+    char* fn = create_temp_file("scampref", NULL);
     printf("Creating scamp catalog: %s\n", fn);
     scamp_cat_t* scamp = scamp_catalog_open_for_writing(fn, TRUE);
     scamp_ref_t obj;


### PR DESCRIPTION
create_temp_file() is called from many places with hardcoded /tmp directory what fails in sandboxed environments. This change attempts to use TMP env variable in such case.