### PR TITLE
Add Github CI action to build the project automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: compile
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make


### PR DESCRIPTION
Adding this single file will automatically run a build via [Github Actions](https://github.com/features/actions).

Whenever a Pull Request is made, the action will check and inform if the build is failing.

(I think actions are enabled by default, but if they aren't, you can enable them in the Settings for this repository)