### PR TITLE
Add new switch --version to solve-field

### DIFF
--- a/solver/solve-field.c
+++ b/solver/solve-field.c
@@ -43,6 +43,7 @@
 static an_option_t options[] = {
     {'h', "help",		   no_argument, NULL,
      "print this help message" },
+    {'\x95', "version", no_argument, NULL, "print version string and exit"},
     {'v', "verbose",       no_argument, NULL,
      "be more chatty -- repeat for even more verboseness" },
     {'D', "dir", required_argument, "directory",
@@ -901,6 +902,10 @@ int main(int argc, char** args) {
             break;
         case 'J':
             skip_solved = TRUE;
+            break;
+        case '\x95':
+            printf("%s\n", AN_GIT_REVISION);
+            exit(rtn);
             break;
         default:
             res = augment_xylist_parse_option(c, optarg, allaxy);


### PR DESCRIPTION
A very small change, just adds the --version switch to the solve-field command line utility.