### PR TITLE
Allow build-astrometry-index to build tiny indexes (presets below -P -5)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.89-3-gabe3582f'
+__version__ = '0.89-5-ga3fbf4eb'

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.89'
+__version__ = '0.89-3-gabe3582f'

--- a/include/astrometry/healpix-utils.h
+++ b/include/astrometry/healpix-utils.h
@@ -46,4 +46,11 @@ il* healpix_region_search(int seed, il* seeds, int Nside,
                           int depth);
 
 
+ll* healpix_region_searchl(int64_t seed, ll* seeds, int Nside,
+                           ll* accepted, ll* rejected,
+                           int (*accept)(int64_t hp, void* token),
+                           void* token,
+                           int depth);
+
+
 #endif

--- a/include/astrometry/healpix.h
+++ b/include/astrometry/healpix.h
@@ -275,6 +275,10 @@ void healpix_to_xyz(int hp, int Nside, double dx, double dy,
 void healpix_to_xyzarr(int hp, int Nside, double dx, double dy,
 					   double* xyz);
 
+void healpixl_to_xyzarr(int64_t hp, int Nside, double dx, double dy,
+                        double* xyz);
+
+
 /**
    Same as healpix_to_xyz, but returns (RA,DEC) in radians.
 */

--- a/include/astrometry/healpix.h
+++ b/include/astrometry/healpix.h
@@ -212,6 +212,7 @@ an output resolution "outnside", returns the healpix index at the
 output resolution.
  */
 void healpix_convert_nside(int hp, int nside, int outnside, int* outhp);
+void healpix_convert_nsidel(int64_t hp, int nside, int outnside, int64_t* outhp);
 
 /**
    Converts (RA, DEC) coordinates (in radians) to healpix index.

--- a/include/astrometry/intmap.h
+++ b/include/astrometry/intmap.h
@@ -13,24 +13,7 @@
  Maps integers to lists of objects.
  */
 
-
-// FIXME -- would this work better with "bt" for the keys?
-struct intmap {
-    // dense only:
-    bl** dense;
-    int ND;
-
-    // sparse only:
-    il* keys;
-    // list of bl*
-    pl* lists;
-
-    // common:
-    // list blocksize
-    int blocksize;
-    // data size
-    int datasize;
-};
+struct intmap;
 typedef struct intmap intmap_t;
 
 /**
@@ -65,6 +48,19 @@ void intmap_append(intmap_t* it, int key, void* pval);
  The iteration proceeds in a random order.
  */
 anbool intmap_get_entry(intmap_t* it, int index, int* key, bl** list);
+
+
+
+
+
+struct longmap;
+typedef struct longmap longmap_t;
+longmap_t* longmap_new(int datasize, int subblocksize, int blocksize, int Ndense);
+void longmap_free(longmap_t* it);
+bl* longmap_find(longmap_t* it, int64_t key, anbool create);
+void longmap_append(longmap_t* it, int64_t key, void* pval);
+anbool longmap_get_entry(longmap_t* it, int index, int64_t* key, bl** list);
+
 
 #endif
 

--- a/solver/build-index-main.c
+++ b/solver/build-index-main.c
@@ -232,9 +232,10 @@ int main(int argc, char** argv) {
     }
 
     if (preset > -100) {
-        // I don't think we can do -6 easily (due to healpix limitations)
-        const int minpreset = -5;
-        double scales[] = { 
+        // presets of -6 and below require 64-bit healpixes
+        const int minpreset = -10;
+        double scales[] = {
+            0.06, 0.09, 0.13, 0.18, 0.25,
             0.35, 0.5, 0.7, 1., 1.4,
             2., 2.8, 4., 5.6, 8., 11., 16., 22., 30., 42., 60., 85.,
             120., 170., 240., 340., 480., 680., 1000., 1400., 2000. };

--- a/solver/build-index-main.c
+++ b/solver/build-index-main.c
@@ -74,7 +74,7 @@ static void print_help(char* progname) {
            "\n"
            "      [-M]: in-memory (don't use temp files)\n"
            "      [-T]: don't delete temp files\n"
-           "      [-t <temp-dir>]: use this temp direcotry (default: /tmp)\n"
+           "      [-t <temp-dir>]: use this temp directory (default: /tmp)\n"
            "      [-v]: add verbosity.\n"
            "\n", progname);
 }

--- a/solver/quad-builder.c
+++ b/solver/quad-builder.c
@@ -71,9 +71,9 @@ check_inbox(pquad_t* pq, int* inds, int ninds, double* stars) {
         double r;
         ind = inds[i];
         starpos = stars + ind*3;
-        logverb("Star position: [%.4f, %.4f, %.4f]\n",
+        logverb("Star position: [%.5f, %.5f, %.5f]\n",
                 starpos[0], starpos[1], starpos[2]);
-        logverb("MidAB: [%.4f, %.4f, %.4f]\n",
+        logverb("MidAB: [%.5f, %.5f, %.5f]\n",
                 pq->midAB[0], pq->midAB[1], pq->midAB[2]);
 
         ok = star_coords(starpos, pq->midAB, TRUE, &Dy, &Dx);

--- a/solver/uniformize-catalog.c
+++ b/solver/uniformize-catalog.c
@@ -119,11 +119,12 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
         ERROR("Fine healpixelization Nside must be a multiple of the coarse healpixelization Nside");
         return -1;
     }
-    if (Nside > HP_MAX_INT_NSIDE) {
-        ERROR("Error: maximum healpix Nside = %i", HP_MAX_INT_NSIDE);
-        return -1;
-    }
-
+    /*
+     if (Nside > HP_MAX_INT_NSIDE) {
+     ERROR("Error: maximum healpix Nside = %i", HP_MAX_INT_NSIDE);
+     return -1;
+     }
+     */
     NHP = 12 * Nside * Nside;
     logverb("Healpix Nside: %lli, # healpixes on the whole sky: %lli\n", Nside, NHP);
     if (!allsky) {

--- a/solver/uniformize-catalog.c
+++ b/solver/uniformize-catalog.c
@@ -20,22 +20,32 @@
 #include "boilerplate.h"
 #include "fitsioutils.h"
 
+// use 64-bit healpixes
+typedef int64_t hpint;
+// blocklist types
+typedef ll hpl;
+#define hpl_new ll_new
+#define hpl_free ll_free
+#define hpl_append ll_append
+#define hpl_size ll_size
+#define hpl_sort ll_sort
+
 struct oh_token {
     int hp;
-    int nside;
-    int finenside;
+    hpint nside;
+    hpint finenside;
 };
 
 // Return 1 if the given "hp" is outside the healpix described in "oh_token".
-static int outside_healpix(int hp, void* vtoken) {
+static int outside_healpix(hpint hp, void* vtoken) {
     struct oh_token* token = vtoken;
-    int bighp;
-    healpix_convert_nside(hp, token->finenside, token->nside, &bighp);
+    hpint bighp;
+    healpix_convert_nsidel(hp, token->finenside, token->nside, &bighp);
     return (bighp == token->hp ? 0 : 1);
 }
 
 static anbool is_duplicate(int hp, double ra, double dec, int Nside,
-                           intmap_t* starlists,
+                           longmap_t* starlists,
                            double* ras, double* decs, double dedupr2) {
     double xyz[3];
     int neigh[9];
@@ -50,7 +60,7 @@ static anbool is_duplicate(int hp, double ra, double dec, int Nside,
     nn = 1 + healpix_get_neighbours(hp, neigh+1, Nside);
     for (k=0; k<nn; k++) {
         int otherhp = neigh[k];
-        bl* lst = intmap_find(starlists, otherhp, FALSE);
+        bl* lst = longmap_find(starlists, otherhp, FALSE);
         if (!lst)
             continue;
         for (j=0; j<bl_size(lst); j++) {
@@ -72,13 +82,12 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
                        int bighp, int bignside,
                        int nmargin,
                        // uniformization nside.
-                       int Nside,
+                       int Nside_int,
                        double dedup_radius,
                        int nsweeps,
                        char** args, int argc) {
     anbool allsky;
-    intmap_t* starlists;
-    int NHP;
+    longmap_t* starlists;
     anbool dense = FALSE;
     double dedupr2 = 0.0;
     tfits_type dubl;
@@ -87,7 +96,7 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
     int* outorder = NULL;
     int outi;
     double *ra = NULL, *dec = NULL;
-    il* myhps = NULL;
+    hpl* myhps = NULL;
     int i,j,k;
     int nkeep = nsweeps;
     int noob = 0;
@@ -97,6 +106,11 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
     qfits_header* outhdr = NULL;
     double *sortval = NULL;
 
+    hpint NHP;
+    // up-convert Nside; which Nside will always fit in int32, we do a lot of math
+    // on it where we want the results to be type hpint.
+    hpint Nside = Nside_int;
+    
     if (bignside == 0)
         bignside = 1;
     allsky = (bighp == -1);
@@ -111,10 +125,10 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
     }
 
     NHP = 12 * Nside * Nside;
-    logverb("Healpix Nside: %i, # healpixes on the whole sky: %i\n", Nside, NHP);
+    logverb("Healpix Nside: %lli, # healpixes on the whole sky: %lli\n", Nside, NHP);
     if (!allsky) {
         logverb("Creating index for healpix %i, nside %i\n", bighp, bignside);
-        logverb("Number of healpixes: %i\n", ((Nside/bignside)*(Nside/bignside)));
+        logverb("Number of healpixes: %lli\n", ((Nside/bignside)*(Nside/bignside)));
     }
     logverb("Healpix side length: %g arcmin.\n", healpix_side_length_arcmin(Nside));
 
@@ -175,7 +189,6 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
             }
             logverb("Cut to %i objects\n", N);
         }
-        //free(sortval);
     }
 
     token.nside = bignside;
@@ -184,11 +197,9 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
 
     if (!allsky && nmargin) {
         int bigbighp, bighpx, bighpy;
-        //int ninside;
-        il* seeds = il_new(256);
+        hpl* seeds = hpl_new(256);
         logverb("Finding healpixes in range...\n");
         healpix_decompose_xy(bighp, &bigbighp, &bighpx, &bighpy, bignside);
-        //ninside = (Nside/bignside)*(Nside/bignside);
         // Prime the queue with the fine healpixes that are on the
         // boundary of the big healpix.
         for (i=0; i<((Nside / bignside) - 1); i++) {
@@ -206,26 +217,26 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
             assert(x1 < Nside);
             assert(y0 < Nside);
             assert(y1 < Nside);
-            il_append(seeds, healpix_compose_xy(bigbighp, xx, y0, Nside));
-            il_append(seeds, healpix_compose_xy(bigbighp, xx, y1, Nside));
-            il_append(seeds, healpix_compose_xy(bigbighp, x0, yy, Nside));
-            il_append(seeds, healpix_compose_xy(bigbighp, x1, yy, Nside));
+            hpl_append(seeds, healpix_compose_xyl(bigbighp, xx, y0, Nside));
+            hpl_append(seeds, healpix_compose_xyl(bigbighp, xx, y1, Nside));
+            hpl_append(seeds, healpix_compose_xyl(bigbighp, x0, yy, Nside));
+            hpl_append(seeds, healpix_compose_xyl(bigbighp, x1, yy, Nside));
         }
-        logmsg("Number of boundary healpixes: %zu (Nside/bignside = %i)\n", il_size(seeds), Nside/bignside);
+        logmsg("Number of boundary healpixes: %zu (Nside/bignside = %lli)\n", hpl_size(seeds), Nside/bignside);
 
-        myhps = healpix_region_search(-1, seeds, Nside, NULL, NULL,
-                                      outside_healpix, &token, nmargin);
-        logmsg("Number of margin healpixes: %zu\n", il_size(myhps));
-        il_free(seeds);
+        myhps = healpix_region_searchl(-1, seeds, Nside, NULL, NULL,
+                                       outside_healpix, &token, nmargin);
+        logmsg("Number of margin healpixes: %zu\n", hpl_size(myhps));
+        hpl_free(seeds);
 
-        il_sort(myhps, TRUE);
+        hpl_sort(myhps, TRUE);
         // DEBUG
-        il_check_consistency(myhps);
-        il_check_sorted_ascending(myhps, TRUE);
+        //il_check_consistency(myhps);
+        //il_check_sorted_ascending(myhps, TRUE);
     }
 
     dedupr2 = arcsec2distsq(dedup_radius);
-    starlists = intmap_new(sizeof(int32_t), nkeep, 0, dense);
+    starlists = longmap_new(sizeof(int32_t), nkeep, 0, dense);
 
     logverb("Placing stars in grid cells...\n");
     for (i=0; i<N; i++) {
@@ -254,7 +265,7 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
             continue;
         }
 
-        lst = intmap_find(starlists, hp, TRUE);
+        lst = longmap_find(starlists, hp, TRUE);
         /*
          printf("list has %i existing entries.\n", bl_size(lst));
          for (k=0; k<bl_size(lst); k++) {
@@ -303,8 +314,8 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
         int32_t j32;
         for (i=0;; i++) {
             bl* lst;
-            int hp;
-            if (!intmap_get_entry(starlists, i, &hp, &lst))
+            int64_t hp;
+            if (!longmap_get_entry(starlists, i, &hp, &lst))
                 break;
             if (bl_size(lst) <= k)
                 continue;
@@ -330,7 +341,7 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
         }
 
     }
-    intmap_free(starlists);
+    longmap_free(starlists);
     starlists = NULL;
 
     //////
@@ -355,7 +366,7 @@ int uniformize_catalog(fitstable_t* intable, fitstable_t* outtable,
         fits_add_long_history(outhdr, "    (ie, for mag-like sort columns)");
     else
         fits_add_long_history(outhdr, "    (ie, for flux-like sort columns)");
-    fits_add_long_history(outhdr, "  uniformization nside: %i", Nside);
+    fits_add_long_history(outhdr, "  uniformization nside: %i", (int)Nside);
     fits_add_long_history(outhdr, "    (ie, side length ~ %g arcmin)", healpix_side_length_arcmin(Nside));
     fits_add_long_history(outhdr, "  deduplication scale: %g arcsec", dedup_radius);
     fits_add_long_history(outhdr, "  number of sweeps: %i", nsweeps);

--- a/util/healpix.c
+++ b/util/healpix.c
@@ -39,6 +39,9 @@ static void intltohp(int64_t pix, hp_t* hp, int Nside) {
 static void inttohp(int pix, hp_t* hp, int Nside) {
     healpix_decompose_xy(pix, &hp->bighp, &hp->x, &hp->y, Nside);
 }
+static void longtohp(int64_t pix, hp_t* hp, int Nside) {
+    healpix_decompose_xyl(pix, &hp->bighp, &hp->x, &hp->y, Nside);
+}
 
 static void hp_decompose(hp_t* hp, int* php, int* px, int* py) {
     if (php)
@@ -1132,6 +1135,13 @@ void healpix_to_xyzarr(int ihp, int Nside,
                        double* xyz) {
     hp_t hp;
     inttohp(ihp, &hp, Nside);
+    hp_to_xyz(&hp, Nside, dx, dy, xyz, xyz+1, xyz+2);
+}
+
+void healpixl_to_xyzarr(int64_t ihp, int Nside, double dx, double dy,
+                        double* xyz) {
+    hp_t hp;
+    longtohp(ihp, &hp, Nside);
     hp_to_xyz(&hp, Nside, dx, dy, xyz, xyz+1, xyz+2);
 }
 

--- a/util/healpix.c
+++ b/util/healpix.c
@@ -407,6 +407,14 @@ void healpix_convert_nside(int hp, int nside, int outnside, int* outhp) {
     *outhp = healpix_compose_xy(basehp, ox, oy, outnside);
 }
 
+void healpix_convert_nsidel(int64_t hp, int nside, int outnside, int64_t* outhp) {
+    int basehp, x, y;
+    int ox, oy;
+    healpix_decompose_xyl(hp, &basehp, &x, &y, nside);
+    healpix_convert_xy_nside(x, y, nside, outnside, &ox, &oy);
+    *outhp = healpix_compose_xyl(basehp, ox, oy, outnside);
+}
+
 void healpix_convert_xy_nside(int x, int y, int nside, int outnside,
                               int* outx, int* outy) {
     double fx, fy;

--- a/util/intmap.c
+++ b/util/intmap.c
@@ -10,113 +10,30 @@
 #define IMGLUE(n,f) IMGLUE2(n,f)
 
 #define key_t int
-#define nl il
-#define KL(x) IMGLUE(nl, x)
+#define kl il
+#define maptype intmap
+#define map_t IMGLUE(maptype, t)
 
-intmap_t* intmap_new(int datasize, int subblocksize, int blocksize,
-                     int Ndense) {
-    intmap_t* im = calloc(1, sizeof(intmap_t));
-    if (!blocksize)
-        blocksize = 4096;
-    im->blocksize = subblocksize;
-    im->datasize = datasize;
-    if (Ndense) {
-        im->ND = Ndense;
-        im->dense = calloc(im->ND, sizeof(bl*));
-    } else {
-        im->keys = KL(new)(blocksize);
-        im->lists = pl_new(blocksize);
-    }
-    return im;
-}
+#define KL(x) IMGLUE(kl, x)
+#define IMAP(x) IMGLUE(maptype, x)
 
-void intmap_free(intmap_t* im) {
-    int i;
-    if (im->lists) {
-        for (i=0; i<pl_size(im->lists); i++) {
-            bl* lst = pl_get(im->lists, i);
-            bl_free(lst);
-        }
-        pl_free(im->lists);
-    }
-    if (im->dense) {
-        for (i=0; i<im->ND; i++) {
-            bl* lst = im->dense[i];
-            if (!lst)
-                continue;
-            bl_free(lst);
-        }
-        free(im->dense);
-    }
-    if (im->keys)
-        KL(free)(im->keys);
-    free(im);
-}
+#include "intmap.inc"
 
-bl* intmap_find(intmap_t* im, key_t key, anbool create) {
-    key_t ind;
-    assert(key >= 0);
-    assert(im);
-    if (!im->dense) {
-        assert(im->keys);
-        assert(im->lists);
-        ind = KL(sorted_index_of)(im->keys, key);
-        if (ind == -1) {
-            bl* lst;
-            if (!create)
-                return NULL;
-            lst = bl_new(im->blocksize, im->datasize);
-            ind = KL(insert_unique_ascending)(im->keys, key);
-            pl_insert(im->lists, ind, lst);
-            return lst;
-        }
-        return pl_get(im->lists, ind);
-    } else {
-        bl* lst;
-        assert(key < im->ND);
-        assert(im->dense);
-        lst = im->dense[key];
-        if (lst)
-            return lst;
-        if (!create)
-            return lst;
-        lst = im->dense[key] = bl_new(im->blocksize, im->datasize);
-        return lst;
-    }
-}
+#undef key_t
+#undef kl
+#undef maptype
 
-void intmap_append(intmap_t* it, int key, void* pval) {
-    bl* lst = intmap_find(it, key, TRUE);
-    bl_append(lst, pval);
-}
+#define key_t int64_t
+#define kl ll
+#define maptype longmap
 
-anbool intmap_get_entry(intmap_t* im, int index,
-                        key_t* p_key, bl** p_list) {
-    assert(im);
-    assert(index >= 0);
-    if (im->dense) {
-        if (index >= im->ND)
-            return FALSE;
-        if (p_key)
-            *p_key = index;
-        if (p_list)
-            *p_list = im->dense[index];
-        return TRUE;
-    }
+#include "intmap.inc"
 
-    assert(im->keys);
-    assert(im->lists);
-    if (index >= KL(size)(im->keys))
-        return FALSE;
-    if (p_key)
-        *p_key = KL(get)(im->keys, index);
-    if (p_list)
-        *p_list = pl_get(im->lists, index);
-    return TRUE;
-}
+#undef key_t
+#undef kl
+#undef maptype
 
+#undef IMAP
+#undef KL
 #undef IMGLUE2
 #undef IMGLUE
-#undef key
-#undef nl
-#undef KL

--- a/util/intmap.inc
+++ b/util/intmap.inc
@@ -1,0 +1,124 @@
+struct maptype {
+    // dense only:
+    bl** dense;
+    int ND;
+
+    // sparse only:
+    kl* keys;
+    // list of bl*
+    pl* lists;
+
+    // common:
+    // list blocksize
+    int blocksize;
+    // data size
+    int datasize;
+};
+typedef struct maptype map_t;
+
+// intmap_t* intmap_new(...)
+map_t* IMAP(new)(int datasize, int subblocksize, int blocksize,
+                     int Ndense) {
+    map_t* im = calloc(1, sizeof(map_t));
+    if (!blocksize)
+        blocksize = 4096;
+    im->blocksize = subblocksize;
+    im->datasize = datasize;
+    if (Ndense) {
+        im->ND = Ndense;
+        im->dense = calloc(im->ND, sizeof(bl*));
+    } else {
+        im->keys = KL(new)(blocksize);
+        im->lists = pl_new(blocksize);
+    }
+    return im;
+}
+
+// void intmap_free(intmap_t*)
+void IMAP(free)(map_t* im) {
+    int i;
+    if (im->lists) {
+        for (i=0; i<pl_size(im->lists); i++) {
+            bl* lst = pl_get(im->lists, i);
+            bl_free(lst);
+        }
+        pl_free(im->lists);
+    }
+    if (im->dense) {
+        for (i=0; i<im->ND; i++) {
+            bl* lst = im->dense[i];
+            if (!lst)
+                continue;
+            bl_free(lst);
+        }
+        free(im->dense);
+    }
+    if (im->keys)
+        KL(free)(im->keys);
+    free(im);
+}
+
+// bl* intmap_find(intmap_t* im, key_t key, anbool create);
+bl* IMAP(find)(map_t* im, key_t key, anbool create) {
+    key_t ind;
+    assert(key >= 0);
+    assert(im);
+    if (!im->dense) {
+        assert(im->keys);
+        assert(im->lists);
+        ind = KL(sorted_index_of)(im->keys, key);
+        if (ind == -1) {
+            bl* lst;
+            if (!create)
+                return NULL;
+            lst = bl_new(im->blocksize, im->datasize);
+            ind = KL(insert_unique_ascending)(im->keys, key);
+            pl_insert(im->lists, ind, lst);
+            return lst;
+        }
+        return pl_get(im->lists, ind);
+    } else {
+        bl* lst;
+        assert(key < im->ND);
+        assert(im->dense);
+        lst = im->dense[key];
+        if (lst)
+            return lst;
+        if (!create)
+            return lst;
+        lst = im->dense[key] = bl_new(im->blocksize, im->datasize);
+        return lst;
+    }
+}
+
+// void intmap_append(intmap_t* it, int key, void* pval)
+void IMAP(append)(map_t* it, key_t key, void* pval) {
+    bl* lst = IMAP(find)(it, key, TRUE);
+    bl_append(lst, pval);
+}
+
+// anbool intmap_get_entry(intmap_t* im, int index, key_t* p_key, bl** p_list);
+anbool IMAP(get_entry)(map_t* im, int index,
+                       key_t* p_key, bl** p_list) {
+    assert(im);
+    assert(index >= 0);
+    if (im->dense) {
+        if (index >= im->ND)
+            return FALSE;
+        if (p_key)
+            *p_key = index;
+        if (p_list)
+            *p_list = im->dense[index];
+        return TRUE;
+    }
+
+    assert(im->keys);
+    assert(im->lists);
+    if (index >= KL(size)(im->keys))
+        return FALSE;
+    if (p_key)
+        *p_key = KL(get)(im->keys, index);
+    if (p_list)
+        *p_list = pl_get(im->lists, index);
+    return TRUE;
+}


### PR DESCRIPTION
Presets below -5 cause the healpix number to overflow 32 bits.  This PR uses 64-bit healpixes to allow finer index files to be built.
