### PR TITLE
net: Replace deprecated PickleSerializer

### DIFF
--- a/net/settings_common.py
+++ b/net/settings_common.py
@@ -89,7 +89,7 @@ PORTAL_LOGFILE = LOG_DIR + 'portal.log'
 VO_LOGFILE = LOG_DIR + 'vo.log'
 
 # http://stackoverflow.com/questions/20301338/django-openid-auth-typeerror-openid-yadis-manager-yadisservicemanager-object-is
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 
 # must match fixtures/initial_data.json
 MACHINE_USERNAME = "an-machine"


### PR DESCRIPTION
Django 5.x has finally removed PickleSerializer (https://github.com/django/django/pull/15139).

JSONSerializer is the default serializer now, and with Django 5.0 released Dec 4th, the code wouldn't work anymore for me.