### PR TITLE
Refactor distutils -> setuptools

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -63,7 +63,7 @@ In Ubunutu 20.04::
     $ sudo apt install build-essential curl git file pkg-config swig \
            libcairo2-dev libnetpbm10-dev netpbm libpng-dev libjpeg-dev \
            zlib1g-dev libbz2-dev libcfitsio-dev wcslib-dev \
-           python3 python3-pip python3-distutils python3-dev \
+           python3 python3-pip python3-dev \
            python3-numpy python3-scipy python3-pil
     $ pip install fitsio # or astropy
 

--- a/libkd/setup-min.py
+++ b/libkd/setup-min.py
@@ -1,7 +1,7 @@
 # This file is part of libkd.
 # Licensed under a 3-clause BSD style license - see LICENSE
 from __future__ import print_function
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os.path
 
 from numpy import get_include

--- a/libkd/setup.py
+++ b/libkd/setup.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 # This file is part of libkd.
 # Licensed under a 3-clause BSD style license - see LICENSE
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os.path
 
 from numpy import get_include

--- a/plot/setup.py
+++ b/plot/setup.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(dotdot, 'util'))
 from an_build_ext import an_build_ext
 from setuputils import *
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 import numpy
 numpy_inc = numpy.get_include()

--- a/sdss/setup.py
+++ b/sdss/setup.py
@@ -1,6 +1,6 @@
 # This file is part of the Astrometry.net suite.
 # Licensed under a 3-clause BSD style license - see LICENSE
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 import sys
 

--- a/setup-libkd.py
+++ b/setup-libkd.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 from numpy import get_include
 numpy_inc = get_include()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from setuptools.command.install import install
 import subprocess
 import os

--- a/solver/setup-solver.py
+++ b/solver/setup-solver.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.join(dotdot, 'util'))
 
 
 from an_build_ext import an_build_ext
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import numpy
 
 numpy_inc = [numpy.get_include()]

--- a/util/an_build_ext.py
+++ b/util/an_build_ext.py
@@ -1,9 +1,14 @@
 # This file is part of the Astrometry.net suite.
 # Licensed under a 3-clause BSD style license - see LICENSE
-from distutils.command.build_ext import build_ext # as _build_py
-#from distutils.command import build_ext as _build_ext
-from distutils.dep_util import newer_group, newer
-from distutils import log
+from setuptools.command.build_ext import build_ext # as _build_py
+#from setuptools.command import build_ext as _build_ext
+try:
+    from setuptools.modified import newer_group, newer
+except ModuleNotFoundError:
+    from setuptools import distutils
+    newer_group = distutils.dep_util.newer_group
+    newer = distutils.dep_util.newer
+import logging as log
 import os
 
 class an_build_ext(build_ext):

--- a/util/makefile.common
+++ b/util/makefile.common
@@ -118,7 +118,7 @@ SHAREDLIBFLAGS_DEF := $(shell $(LINKTEST))
 SHAREDLIB_SUFFIX = so
 
 # Cygwin peculiarities:
-# --.dll filename suffix for shared libraries (created by python distutils)
+# --.dll filename suffix for shared libraries (created by python setuptools)
 # -- -fPIC produces warnings
 
 UNAME = $(shell uname -s)
@@ -126,8 +126,8 @@ ifneq (CYGWIN,$(findstring CYGWIN,$(UNAME)))
   SHAREDLIBFLAGS_DEF += -fPIC
 endif 
 
-# Get the library suffix used by python distutils (.dll on cygwin, .so elsewhere for py2; .PLATFORM.so for py3)
-PYTHON_SO_EXT ?= $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or sysconfig.get_config_var('SO'))")
+# Get the library suffix used by python sysconfig (.dll on cygwin, .so elsewhere for py2; .PLATFORM.so for py3)
+PYTHON_SO_EXT ?= $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or sysconfig.get_config_var('SO'))")
 
 # Set a default, otherwise terrible things happen:
 #   in util/Makefile : clean: rm -f *$(PYTHON_SO_EXT)

--- a/util/setup.py
+++ b/util/setup.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(path)))
 
 from an_build_ext import *
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import numpy
 from setuputils import *
 


### PR DESCRIPTION
To address #286 

It builds on python3.12 and I can run the demo usage from travis ci config. I also made sure it still builds on python3.10.

I've done very limited testing so far, but since this is a minor build system change that replaces distutils with commands specifically designed to be compatible with distutils, I want to believe that if it builds and works with no catastrophic issues at all, it should generally just work for everything.