### PR TITLE
fix for numpy 2.0

### DIFF
--- a/libkd/pyspherematch.c
+++ b/libkd/pyspherematch.c
@@ -15,6 +15,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
+#undef I
 
 #include "os-features.h"
 #include "keywords.h"

--- a/util/util.i
+++ b/util/util.i
@@ -164,7 +164,7 @@ void log_set_level(int lvl);
         printf("  descr kind: '%c'\n", desc->kind);
         printf("  descr type: '%c'\n", desc->type);
         printf("  descr byteorder: '%c'\n", desc->byteorder);
-        printf("  descr elsize: %i\n", desc->elsize);
+        printf("  descr elsize: %i\n", (int)PyArray_ITEMSIZE(obj));
     }
 
 


### PR DESCRIPTION
Fixes #297

Numpy 2.0 [removed `eslize`](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#migration-c-descr)

Also, not sure how this is typically handled but `numpy/arrayobject.h` [now includes `complex.h`](https://github.com/numpy/numpy/blob/1d49c7f7ff527c696fc26ab2278ad51632a66660/numpy/_core/include/numpy/npy_common.h#L376), which defines an `I` macro conflicting with local variables

```c
pyspherematch.c:338:17: error: expected identifier or '('
    npy_uint32* I;
                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/complex.h:42:11: note: expanded from macro 'I'
#define I _Complex_I
```