### PR TITLE
Fix some memory leaks

### DIFF
--- a/solver/solver.c
+++ b/solver/solver.c
@@ -1358,6 +1358,9 @@ static void resolve_matches(kdtree_qres_t* krez, const double *field_xy,
         if (solver_handle_hit(solver, &mo, NULL, FALSE))
             solver->quit_now = TRUE;
 
+        sip_free(mo.sip);
+        mo.sip = NULL;
+
         if (unlikely(solver->quit_now))
             return;
     }

--- a/solver/tweak2.c
+++ b/solver/tweak2.c
@@ -318,6 +318,7 @@ sip_t* tweak2(const double* fieldxy, int Nfield,
                 free(fieldsigma2s);
                 free(indexpix);
                 free(indexin);
+                free(refperm);
                 return NULL;
             }
 
@@ -362,7 +363,7 @@ sip_t* tweak2(const double* fieldxy, int Nfield,
                                             W, H, distractors,
                                             logodds_bail, LARGE_VAL,
                                             &besti, &odds, &theta, NULL,
-                                            &testperm, &refperm);
+                                            NULL, &refperm);
 
             logverb("Logodds: %g\n", logodds);
             verify_count_hits(theta, besti, &nmatch, &nconf, &ndist);
@@ -434,6 +435,7 @@ sip_t* tweak2(const double* fieldxy, int Nfield,
                 free(fieldsigma2s);
                 free(indexpix);
                 free(indexin);
+                free(refperm);
                 return NULL;
             }
 
@@ -526,7 +528,7 @@ sip_t* tweak2(const double* fieldxy, int Nfield,
                                         W, H, distractors,
                                         logodds_bail, LARGE_VAL,
                                         &besti, &odds, &theta, NULL,
-                                        &testperm, &refperm);
+                                        NULL, &refperm);
         logverb("Logodds: %g\n", logodds);
         verify_count_hits(theta, besti, &nmatch, &nconf, &ndist);
         logverb("%i matches, %i distractors, %i conflicts (at best log-odds); %i field sources, %i index sources\n", nmatch, ndist, nconf, Nfield, Nin);

--- a/util/simplexy.c
+++ b/util/simplexy.c
@@ -331,6 +331,8 @@ int simplexy_run(simplexy_t* s) {
     mask = malloc((size_t)nx*(size_t)ny);
     if (!dmask(smoothed, nx, ny, limit, s->dpsf, mask)) {
         FREEVEC(smoothfree);
+        FREEVEC(bgfree);
+        FREEVEC(mask);
         return 0;
     }
     FREEVEC(smoothfree);


### PR DESCRIPTION
Hello

While using valgrind on my own software, I got some memory leaks notifications in astrometry.net, so I took some time to fix them.

The results I get on my test data is the same, so hopefully there isn't an edge-case I didn't saw somewhere.