### PR TITLE
Replace removed Python 2 C API macros for SWIG 4.5.0 compatibility

### DIFF
--- a/libkd/pyspherematch.c
+++ b/libkd/pyspherematch.c
@@ -7,7 +7,7 @@
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K
-#define PyInt_FromLong PyLong_FromLong
+#define PyLong_FromLong PyLong_FromLong
 #endif
 
 #include <stdio.h>
@@ -458,7 +458,7 @@ static PyMethodDef kdtree_methods[] = {
 };
 
 static PyObject* KdTree_n(KdObject* self, void* closure) {
-    return PyInt_FromLong(kdtree_n(self->kd));
+    return PyLong_FromLong(kdtree_n(self->kd));
 }
 
 static PyObject* KdTree_bbox(KdObject* self, void* closure) {
@@ -564,9 +564,9 @@ static void callback_dualtree2(void* v, int ind1, int ind2, double dist2) {
         lst = PyList_New(1);
         // SetItem steals a ref -- that's what we want.
         PyList_SetItem(dt->indlist, ind1, lst);
-        PyList_SET_ITEM(lst, 0, PyInt_FromLong(ind2));
+        PyList_SET_ITEM(lst, 0, PyLong_FromLong(ind2));
     } else {
-        PyList_Append(lst, PyInt_FromLong(ind2));
+        PyList_Append(lst, PyLong_FromLong(ind2));
     }
 }
 

--- a/plot/plotstuff.i
+++ b/plot/plotstuff.i
@@ -125,7 +125,7 @@ void free(void* ptr);
         Py_DECREF($result);
         $result = PyList_New(3);
         for (i=0; i<3; i++) {
-            PyObject *o = PyInt_FromLong((long)$1[i]);
+            PyObject *o = PyLong_FromLong((long)$1[i]);
             PyList_SetItem($result,i,o);
         }
     }
@@ -142,7 +142,7 @@ void free(void* ptr);
     for (i=0; i<3; i++) {
         PyObject *o = PySequence_GetItem($input, i);
         if (PyNumber_Check(o)) {
-            temp[i] = (int)PyInt_AsLong(o);
+            temp[i] = (int)PyLong_AsLong(o);
         } else {
             PyErr_SetString(PyExc_ValueError,"Sequence elements must be numbers");
             return NULL;

--- a/util/index_pyutils.c
+++ b/util/index_pyutils.c
@@ -70,7 +70,7 @@ static PyObject* qidxfile_get_quad_list(PyObject* self, PyObject* args) {
 static PyObject* pyval_int(void* v, int index) {
     PyObject* pyval;
     int* i = (int*)v;
-    pyval = PyInt_FromLong((long)i[index]);
+    pyval = PyLong_FromLong((long)i[index]);
     assert(pyval);
     return pyval;
 }

--- a/util/util.i
+++ b/util/util.i
@@ -921,7 +921,7 @@ def lanczos_shift_image(img, dx, dy, order=3, weight=None,
   D = $1->dimquads;
   $result = PyList_New(D);
   for (i = 0; i < D; i++) {
-      PyObject *o = PyInt_FromLong($3[i]);
+      PyObject *o = PyLong_FromLong($3[i]);
       PyList_SetItem($result, i, o);
   }
 }
@@ -996,11 +996,11 @@ long quadfile_addr(index_t* ind);
   int i;
   int nn;
   // convert $result to nn
-  //nn = (int)PyInt_AsLong($result);
+  //nn = (int)PyLong_AsLong($result);
   nn = result;
   $result = PyList_New(nn);
   for (i = 0; i < nn; i++) {
-      PyObject *o = PyInt_FromLong($1[i]);
+      PyObject *o = PyLong_FromLong($1[i]);
       PyList_SetItem($result, i, o);
   }
 }
@@ -1018,7 +1018,7 @@ long quadfile_addr(index_t* ind);
   N = il_size($1);
   $result = PyList_New(N);
   for (i = 0; i < N; i++) {
-      PyObject *o = PyInt_FromLong(il_get($1, i));
+      PyObject *o = PyLong_FromLong(il_get($1, i));
       PyList_SetItem($result, i, o);
   }
 }
@@ -2296,7 +2296,7 @@ static PyObject* anwcs_xy2rd_wrapper(const anwcs_t* wcs,
             d = *(double*)PyArray_DATA((PyArrayObject*)py);
             py = PyFloat_FromDouble(d);
             i = *(int*)PyArray_DATA((PyArrayObject*)pok);
-            pok = PyInt_FromLong(i);
+            pok = PyLong_FromLong(i);
             ret = Py_BuildValue("(NNN)", pok, px, py);
         } else {
             // Grab the results -- note "4,2,3" order -- ok,x,y


### PR DESCRIPTION
Submitting a PR I've received by a user in Fedora Linux downstream: https://src.fedoraproject.org/rpms/astrometry/pull-request/1

> SWIG 4.5.0 removed Python 2 compatibility macros (PyInt_, PyString_, SWIG_Python_str_*) from its runtime header pyhead.swg (see commit [Python: Remove Python 2 compatibility macros](https://github.com/swig/swig/commit/79f7a2b7cb7ddc256eba09c8770133148025171d)). These macros mapped old Python 2 C API names to their Python 3 equivalents. Packages that reference them in custom SWIG typemaps or pre-generated wrapper code now fail to compile.
> 
> This patch replaces all occurrences with the corresponding Python 3 C API functions. The replacements are safe since the macros were already aliased to these exact functions in SWIG's Python 3 code path.